### PR TITLE
Fix PayBridge gateway registration

### DIFF
--- a/PayBridge.SDK.Example/Program.cs
+++ b/PayBridge.SDK.Example/Program.cs
@@ -80,7 +80,7 @@ builder.Services.AddSwaggerGen(c =>
 // This example shows PATTERN A so you can see how the config file maps to
 // the object model.
 
-builder.Services.AddPayBridge(config =>
+builder.Services.AddPayBridge(builder.Configuration, config =>
 {
     // Read all gateway keys from appsettings.json.
     // The SDK binds "PaymentGatewayConfig" automatically via IOptions.

--- a/PayBridge.SDK.Test/Unit/IServiceCollectionExtensionsTests.cs
+++ b/PayBridge.SDK.Test/Unit/IServiceCollectionExtensionsTests.cs
@@ -1,0 +1,93 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using PayBridge.SDK.Application.Dtos;
+using PayBridge.SDK.Enums;
+using PayBridge.SDK.Interfaces;
+using Xunit;
+
+namespace PayBridge.SDK.Test.Unit;
+
+[Trait("Category", "Unit")]
+public class IServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddPayBridge_BindsConfiguration_AndAppliesCodeOverrides_ToSingletonAndOptions()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["PaymentGatewayConfig:DefaultGateway"] = "Stripe",
+            ["PaymentGatewayConfig:EnabledGateways:0"] = "Paystack",
+            ["PaymentGatewayConfig:Paystack:SecretKey"] = "sk_from_config"
+        });
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddPayBridge(configuration, config =>
+        {
+            config.Paystack.SecretKey = "sk_from_code";
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var config = provider.GetRequiredService<PaymentGatewayConfig>();
+        var options = provider.GetRequiredService<IOptions<PaymentGatewayConfig>>();
+
+        config.DefaultGateway.Should().Be(PaymentGatewayType.Stripe);
+        config.EnabledGateways.Should().ContainSingle().Which.Should().Be(PaymentGatewayType.Paystack);
+        config.Paystack.SecretKey.Should().Be("sk_from_code");
+        options.Value.Should().BeSameAs(config);
+    }
+
+    [Fact]
+    public void AddPayBridge_RegistersEnabledGateway_AsIPaymentGateway()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["PaymentGatewayConfig:EnabledGateways:0"] = "PeachPayments",
+            ["PaymentGatewayConfig:PeachPayments:EntityId"] = "test_entity",
+            ["PaymentGatewayConfig:PeachPayments:AccessToken"] = "test_token"
+        });
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddPayBridge(configuration);
+
+        using var provider = services.BuildServiceProvider();
+
+        var gateways = provider.GetServices<IPaymentGateway>().ToList();
+
+        gateways.Should().ContainSingle();
+        gateways[0].GatewayType.Should().Be(PaymentGatewayType.PeachPayments);
+    }
+
+    [Fact]
+    public void AddPayBridge_WhenEnabledGatewaysIsEmpty_RegistersOnlyConfiguredGateways()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["PaymentGatewayConfig:Paystack:SecretKey"] = "sk_test_paystack",
+            ["PaymentGatewayConfig:Stripe:SecretKey"] = "YOUR_STRIPE_SECRET_KEY"
+        });
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddPayBridge(configuration);
+
+        using var provider = services.BuildServiceProvider();
+
+        var gateways = provider.GetServices<IPaymentGateway>().ToList();
+
+        gateways.Should().ContainSingle();
+        gateways[0].GatewayType.Should().Be(PaymentGatewayType.Paystack);
+    }
+
+    private static IConfiguration BuildConfiguration(Dictionary<string, string?> values)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+    }
+}

--- a/PayBridge.SDK/Externsions/IServiceCollectionExtensions.cs
+++ b/PayBridge.SDK/Externsions/IServiceCollectionExtensions.cs
@@ -1,11 +1,13 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using PayBridge.SDK.Application.Dtos;
 using PayBridge.SDK.Enums;
 using PayBridge.SDK.Interfaces;
 
 namespace PayBridge.SDK;
+
 public static class IServiceCollectionExtensions
 {
     private const int RetryCount = 3;
@@ -79,27 +81,50 @@ public static class IServiceCollectionExtensions
     /// <exception cref="ArgumentNullException"></exception>
     public static IServiceCollection AddPayBridge(this IServiceCollection services, Action<PaymentGatewayConfig> configAction)
     {
-        if (services == null)
-        {
-            throw new ArgumentNullException(nameof(services));
-        }
-
         if (configAction == null)
         {
             throw new ArgumentNullException(nameof(configAction));
         }
 
-        services.AddOptions<PaymentGatewayConfig>()
-            .Configure<IConfiguration>((settings, configuration) =>
-            {
-                configuration.GetSection("PaymentGatewayConfig").Bind(settings);
-            });
+        var configuration = services
+            .FirstOrDefault(descriptor => descriptor.ServiceType == typeof(IConfiguration))
+            ?.ImplementationInstance as IConfiguration;
 
+        return AddPayBridgeCore(services, configuration, configAction);
+    }
 
-        // Configure the SDK
+    /// <summary>
+    /// Add PayBridge SDK services and bind PaymentGatewayConfig from configuration before applying optional overrides.
+    /// </summary>
+    public static IServiceCollection AddPayBridge(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        Action<PaymentGatewayConfig>? configAction = null)
+    {
+        if (configuration == null)
+        {
+            throw new ArgumentNullException(nameof(configuration));
+        }
+
+        return AddPayBridgeCore(services, configuration, configAction);
+    }
+
+    private static IServiceCollection AddPayBridgeCore(
+        IServiceCollection services,
+        IConfiguration? configuration,
+        Action<PaymentGatewayConfig>? configAction)
+    {
+        if (services == null)
+        {
+            throw new ArgumentNullException(nameof(services));
+        }
+
         var config = new PaymentGatewayConfig();
-        configAction(config);
+        configuration?.GetSection("PaymentGatewayConfig").Bind(config);
+        configAction?.Invoke(config);
+
         services.AddSingleton(config);
+        services.AddSingleton<IOptions<PaymentGatewayConfig>>(Options.Create(config));
 
         // Register core services
         services.AddScoped<IPaymentService, PaymentService>();
@@ -120,81 +145,76 @@ public static class IServiceCollectionExtensions
     /// <param name="config"></param>
     private static void RegisterGateways(IServiceCollection services, PaymentGatewayConfig config)
     {
-        // If no gateways are explicitly enabled, enable all available ones
+        // If no gateways are explicitly enabled, enable all configured ones.
         if (config.EnabledGateways.Count == 0)
         {
-            services.AddScoped<StripeGateway>();
-            services.AddScoped<PaystackGateway>();
-            services.AddScoped<FlutterwaveGateway>();
-            services.AddScoped<CheckoutGateway>();
-            services.AddScoped<BenefitPayGateway>();
-            services.AddScoped<KnetGateway>();
-            services.AddScoped<MonnifyGateway>();
-            services.AddScoped<IPaymentGateway>(sp => sp.GetRequiredService<MonnifyGateway>());
-            services.AddScoped<SquadGateway>();
-            services.AddScoped<KorapayGateway>();
-            services.AddScoped<IPaymentGateway>(sp => sp.GetRequiredService<KorapayGateway>());
-            services.AddScoped<InterswitchGateway>();
-            AddGatewayRegistration<DpoGroupGateway>(services);
-            services.AddScoped<RemitaGateway>();
-            services.AddScoped<OpayGateway>();
-            services.AddScoped<PawaPayGateway>();
-            services.AddScoped<PeachPaymentsGateway>();
+            foreach (var gateway in Enum.GetValues<PaymentGatewayType>())
+            {
+                if (gateway != PaymentGatewayType.Automatic && IsGatewayConfigured(config, gateway))
+                {
+                    RegisterGateway(services, gateway);
+                }
+            }
+
             return;
         }
 
         // Register only the enabled gateways
         foreach (var gateway in config.EnabledGateways)
         {
-            switch (gateway)
-            {
-                case PaymentGatewayType.Stripe:
-                    AddGatewayRegistration<StripeGateway>(services);
-                    break;
-                case PaymentGatewayType.Paystack:
-                    AddGatewayRegistration<PaystackGateway>(services);
-                    break;
-                case PaymentGatewayType.Flutterwave:
-                    AddGatewayRegistration<FlutterwaveGateway>(services);
-                    break;
-                case PaymentGatewayType.Checkout:
-                    AddGatewayRegistration<CheckoutGateway>(services);
-                    break;
-                case PaymentGatewayType.BenefitPay:
-                    AddGatewayRegistration<BenefitPayGateway>(services);
-                    break;
-                case PaymentGatewayType.Knet:
-                    AddGatewayRegistration<KnetGateway>(services);
-                    break;
-                case PaymentGatewayType.Monnify:
-                    AddGatewayRegistration<MonnifyGateway>(services);
-                    break;
-                case PaymentGatewayType.Squad:
-                    AddGatewayRegistration<SquadGateway>(services);
-                    break;
-                case PaymentGatewayType.Korapay:
-                    AddGatewayRegistration<KorapayGateway>(services);
-                    break;
-                case PaymentGatewayType.Interswitch:
-services.AddScoped<InterswitchGateway>();
-services.AddScoped<IPaymentGateway>(sp => sp.GetRequiredService<InterswitchGateway>());
-                    break;
-                case PaymentGatewayType.Remita:
-                    services.AddScoped<RemitaGateway>();
-                    break;
-                case PaymentGatewayType.Opay:
-                    services.AddScoped<OpayGateway>();
-                    break;
-                case PaymentGatewayType.DpoGroup:
-                    AddGatewayRegistration<DpoGroupGateway>(services);
-                    break;
-                case PaymentGatewayType.PawaPay:
-                    services.AddScoped<PawaPayGateway>();
-                    break;
-                case PaymentGatewayType.PeachPayments:
-                    services.AddScoped<PeachPaymentsGateway>();
-                    break;
-            }
+            RegisterGateway(services, gateway);
+        }
+    }
+
+    private static void RegisterGateway(IServiceCollection services, PaymentGatewayType gateway)
+    {
+        switch (gateway)
+        {
+            case PaymentGatewayType.Stripe:
+                AddGatewayRegistration<StripeGateway>(services);
+                break;
+            case PaymentGatewayType.Paystack:
+                AddGatewayRegistration<PaystackGateway>(services);
+                break;
+            case PaymentGatewayType.Flutterwave:
+                AddGatewayRegistration<FlutterwaveGateway>(services);
+                break;
+            case PaymentGatewayType.Checkout:
+                AddGatewayRegistration<CheckoutGateway>(services);
+                break;
+            case PaymentGatewayType.BenefitPay:
+                AddGatewayRegistration<BenefitPayGateway>(services);
+                break;
+            case PaymentGatewayType.Knet:
+                AddGatewayRegistration<KnetGateway>(services);
+                break;
+            case PaymentGatewayType.Monnify:
+                AddGatewayRegistration<MonnifyGateway>(services);
+                break;
+            case PaymentGatewayType.Squad:
+                AddGatewayRegistration<SquadGateway>(services);
+                break;
+            case PaymentGatewayType.Korapay:
+                AddGatewayRegistration<KorapayGateway>(services);
+                break;
+            case PaymentGatewayType.Interswitch:
+                AddGatewayRegistration<InterswitchGateway>(services);
+                break;
+            case PaymentGatewayType.Remita:
+                AddGatewayRegistration<RemitaGateway>(services);
+                break;
+            case PaymentGatewayType.Opay:
+                AddGatewayRegistration<OpayGateway>(services);
+                break;
+            case PaymentGatewayType.DpoGroup:
+                AddGatewayRegistration<DpoGroupGateway>(services);
+                break;
+            case PaymentGatewayType.PawaPay:
+                AddGatewayRegistration<PawaPayGateway>(services);
+                break;
+            case PaymentGatewayType.PeachPayments:
+                AddGatewayRegistration<PeachPaymentsGateway>(services);
+                break;
         }
     }
 
@@ -217,5 +237,34 @@ services.AddScoped<IPaymentGateway>(sp => sp.GetRequiredService<InterswitchGatew
             "mysql" => "MySql",
             _ => provider
         };
+    }
+
+    private static bool IsGatewayConfigured(PaymentGatewayConfig config, PaymentGatewayType gateway)
+    {
+        return gateway switch
+        {
+            PaymentGatewayType.Paystack => HasValue(config.Paystack.SecretKey),
+            PaymentGatewayType.Flutterwave => HasValue(config.FlutterwaveConfig.SecretKey),
+            PaymentGatewayType.Stripe => HasValue(config.Stripe.SecretKey),
+            PaymentGatewayType.Checkout => HasValue(config.Checkout.SecretKey),
+            PaymentGatewayType.BenefitPay => HasValue(config.BenefitPay.MerchantId) && HasValue(config.BenefitPay.ApiKey),
+            PaymentGatewayType.Knet => HasValue(config.Knet.TransportId) && HasValue(config.Knet.Password),
+            PaymentGatewayType.Monnify => HasValue(config.Monnify.ApiKey) && HasValue(config.Monnify.SecretKey) && HasValue(config.Monnify.ContractCode),
+            PaymentGatewayType.Squad => HasValue(config.Squad.SecretKey),
+            PaymentGatewayType.Korapay => HasValue(config.Korapay.SecretKey),
+            PaymentGatewayType.Interswitch => HasValue(config.Interswitch.ClientId) && HasValue(config.Interswitch.ClientSecret) && HasValue(config.Interswitch.MerchantCode),
+            PaymentGatewayType.Remita => HasValue(config.Remita.MerchantId) && HasValue(config.Remita.ServiceTypeId) && HasValue(config.Remita.ApiKey),
+            PaymentGatewayType.Opay => HasValue(config.Opay.MerchantId) && HasValue(config.Opay.SecretKey),
+            PaymentGatewayType.DpoGroup => HasValue(config.DpoGroup.CompanyToken),
+            PaymentGatewayType.PawaPay => HasValue(config.PawaPay.ApiToken),
+            PaymentGatewayType.PeachPayments => HasValue(config.PeachPayments.EntityId) && HasValue(config.PeachPayments.AccessToken),
+            _ => false
+        };
+    }
+
+    private static bool HasValue(string value)
+    {
+        return !string.IsNullOrWhiteSpace(value) &&
+            !value.StartsWith("YOUR_", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/PayBridge.SDK/Interfaces/ITransactionRepository.cs
+++ b/PayBridge.SDK/Interfaces/ITransactionRepository.cs
@@ -16,7 +16,7 @@ public interface ITransactionRepository
     /// </summary>
     /// <param name="reference"></param>
     /// <returns></returns>
-    Task<PaymentTransaction> GetByReferenceAsync(string reference);
+    Task<PaymentTransaction?> GetByReferenceAsync(string reference);
 
     /// <summary>
     /// updates an existing payment transaction

--- a/PayBridge.SDK/Repositories/TransactionRepository.cs
+++ b/PayBridge.SDK/Repositories/TransactionRepository.cs
@@ -39,7 +39,7 @@ public class TransactionRepository(PayBridgeDbContext dbContext, ILogger<Transac
     }
 
     /// <inheritdoc/>
-    public async Task<PaymentTransaction> GetByReferenceAsync(string reference)
+    public async Task<PaymentTransaction?> GetByReferenceAsync(string reference)
     {
         if (string.IsNullOrEmpty(reference))
         {
@@ -49,8 +49,7 @@ public class TransactionRepository(PayBridgeDbContext dbContext, ILogger<Transac
         _logger.LogInformation("Getting transaction by reference: {Reference}", reference);
 
         return await _dbContext.Transactions
-            .FirstOrDefaultAsync(t => t.TransactionReference == reference)
-            ?? throw new TransactionNotFoundException(reference);
+            .FirstOrDefaultAsync(t => t.TransactionReference == reference);
     }
 
     /// <inheritdoc/>

--- a/PayBridge.SDK/Services/PaymentService.cs
+++ b/PayBridge.SDK/Services/PaymentService.cs
@@ -38,6 +38,11 @@ public class PaymentService : IPaymentService
     {
         ValidateRequest(request);
 
+        if (_gateways.Count == 0)
+        {
+            throw new PaymentGatewayException("No payment gateways are configured");
+        }
+
         // Select gateway or use specified
         PaymentGatewayType selectedGateway = gateway != PaymentGatewayType.Automatic
             ? gateway


### PR DESCRIPTION
## Summary

Fixes PayBridge SDK registration so configuration binding, gateway DI visibility, and transaction lookup semantics match the behavior expected by the example app and payment service.

## What changed

- Bind `PaymentGatewayConfig` from `PaymentGatewayConfig` in configuration before applying code overrides.
- Keep direct `PaymentGatewayConfig` injection and `IOptions<PaymentGatewayConfig>` backed by the same object.
- Register enabled gateways consistently as both concrete gateway types and `IPaymentGateway`.
- When `EnabledGateways` is empty, register only gateways with configured non-placeholder credentials.
- Let `GetByReferenceAsync` return `null` when no transaction exists, matching existing service flow.
- Add focused tests for config binding, options consistency, and gateway registration.

## Validation

- `dotnet test PayBridge.SDK.sln` passed: 90 passed, 2 skipped, 0 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration-based setup support for the SDK initialization.

* **Bug Fixes**
  * Improved error handling with validation for configured payment gateways.
  * Transaction lookup now returns null when no match is found instead of throwing an exception.

* **Tests**
  * Added comprehensive unit tests for SDK dependency injection and gateway registration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->