### PR TITLE
Implement Flutterwave full and partial refunds

### DIFF
--- a/PayBridge.SDK.Test/Helpers/MockHttpMessageHandler.cs
+++ b/PayBridge.SDK.Test/Helpers/MockHttpMessageHandler.cs
@@ -11,9 +11,13 @@ public sealed class MockHttpMessageHandler : HttpMessageHandler
 {
     private readonly Queue<MockHttpResponse> _queue = new();
     private readonly List<HttpRequestMessage> _requests = new();
+    private readonly List<string?> _requestBodies = new();
 
     /// <summary>All requests made through this handler, in order.</summary>
     public IReadOnlyList<HttpRequestMessage> Requests => _requests.AsReadOnly();
+
+    /// <summary>Request bodies captured before request content is disposed.</summary>
+    public IReadOnlyList<string?> RequestBodies => _requestBodies.AsReadOnly();
 
     /// <summary>The most recent request made through this handler.</summary>
     public HttpRequestMessage? LastRequest => _requests.Count > 0 ? _requests[^1] : null;
@@ -46,11 +50,14 @@ public sealed class MockHttpMessageHandler : HttpMessageHandler
 
     // ── Core override ─────────────────────────────────────────────────────────
 
-    protected override Task<HttpResponseMessage> SendAsync(
+    protected override async Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request,
         CancellationToken cancellationToken)
     {
         _requests.Add(request);
+        _requestBodies.Add(request.Content is null
+            ? null
+            : await request.Content.ReadAsStringAsync(cancellationToken));
 
         if (_queue.Count == 0)
         {
@@ -65,7 +72,7 @@ public sealed class MockHttpMessageHandler : HttpMessageHandler
             Content = new StringContent(mock.Body, Encoding.UTF8, mock.ContentType)
         };
 
-        return Task.FromResult(response);
+        return response;
     }
 
     // ── Assertion helpers ─────────────────────────────────────────────────────

--- a/PayBridge.SDK.Test/Integration/FlutterwaveRefundIntegrationTests.cs
+++ b/PayBridge.SDK.Test/Integration/FlutterwaveRefundIntegrationTests.cs
@@ -1,0 +1,66 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using PayBridge.SDK.Application.Dtos;
+using PayBridge.SDK.Test.Helpers;
+using Xunit;
+
+namespace PayBridge.SDK.Test.Integration;
+
+/// <summary>
+/// Opt-in Flutterwave sandbox refund test. Use a dedicated, successful sandbox
+/// transaction that can be refunded exactly once; never provide live credentials.
+/// </summary>
+[Trait("Category", "Integration")]
+public class FlutterwaveRefundIntegrationTests : IntegrationTestBase
+{
+    private readonly FlutterwaveGateway? _gateway;
+    private readonly string? _transactionReference;
+    private readonly decimal _amount;
+
+    public FlutterwaveRefundIntegrationTests()
+        : base(
+            "FLUTTERWAVE_SECRET_KEY",
+            "FLUTTERWAVE_REFUND_TRANSACTION_REFERENCE",
+            "FLUTTERWAVE_REFUND_AMOUNT")
+    {
+        if (ShouldSkip)
+        {
+            return;
+        }
+
+        _transactionReference = GetRequiredEnv("FLUTTERWAVE_REFUND_TRANSACTION_REFERENCE");
+        _amount = decimal.Parse(
+            GetRequiredEnv("FLUTTERWAVE_REFUND_AMOUNT"),
+            System.Globalization.CultureInfo.InvariantCulture);
+        var config = new PaymentGatewayConfig
+        {
+            FlutterwaveConfig = new FlutterwaveConfig
+            {
+                SecretKey = GetRequiredEnv("FLUTTERWAVE_SECRET_KEY")
+            }
+        };
+        _gateway = new FlutterwaveGateway(
+            Options.Create(config),
+            NullLogger<FlutterwaveGateway>.Instance,
+            new RealHttpClientFactory());
+    }
+
+    [SkippableFact]
+    public async Task RefundPaymentAsync_RefundsDedicatedSandboxTransaction()
+    {
+        SkipIfMissingEnvVars();
+
+        var result = await _gateway!.RefundPaymentAsync(
+            PaymentRequestFactory.BuildRefund(request =>
+            {
+                request.TransactionReference = _transactionReference!;
+                request.Amount = _amount;
+                request.Reason = "requested_by_customer";
+            }));
+
+        result.Success.Should().BeTrue(because: result.Message);
+        result.RefundReference.Should().NotBeNullOrWhiteSpace();
+        result.Amount.Should().Be(_amount);
+    }
+}

--- a/PayBridge.SDK.Test/Unit/FlutterwaveGatewayRefundTests.cs
+++ b/PayBridge.SDK.Test/Unit/FlutterwaveGatewayRefundTests.cs
@@ -1,0 +1,181 @@
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using PayBridge.SDK.Application.Dtos;
+using PayBridge.SDK.Dtos.Response;
+using PayBridge.SDK.Enums;
+using PayBridge.SDK.Test.Helpers;
+using Xunit;
+
+namespace PayBridge.SDK.Test.Unit;
+
+[Trait("Category", "Unit")]
+public class FlutterwaveGatewayRefundTests
+{
+    [Theory]
+    [InlineData(1000, "full")]
+    [InlineData(250.50, "partial")]
+    public async Task RefundPaymentAsync_uses_provider_transaction_id_and_explicit_amount(
+        decimal amount,
+        string refundType)
+    {
+        var handler = new MockHttpMessageHandler()
+            .RespondWith(HttpStatusCode.OK, VerificationJson(amount: 1000))
+            .RespondWith(HttpStatusCode.OK, RefundJson(amount, "completed"));
+        var gateway = CreateGateway(new MockHttpClientFactory(handler));
+        var request = PaymentRequestFactory.BuildRefund(value =>
+        {
+            value.TransactionReference = "FLW_MERCHANT_REF";
+            value.Amount = amount;
+            value.Reason = "requested_by_customer";
+        });
+
+        var result = await gateway.RefundPaymentAsync(request);
+
+        result.Success.Should().BeTrue();
+        result.Status.Should().Be(PaymentStatus.Refunded);
+        result.RefundReference.Should().Be("URF_REFUND_123");
+        result.TransactionReference.Should().Be("FLW_MERCHANT_REF");
+        result.Amount.Should().Be(amount);
+        result.Message.Should().Contain(refundType);
+        handler.Requests.Should().HaveCount(2);
+        handler.Requests[0].RequestUri!.PathAndQuery.Should()
+            .Be("/v3/transactions/verify_by_reference?tx_ref=FLW_MERCHANT_REF");
+        handler.Requests[1].RequestUri!.AbsolutePath.Should()
+            .Be("/v3/transactions/987654/refund");
+        using var payload = JsonDocument.Parse(
+            handler.RequestBodies[1]!);
+        payload.RootElement.GetProperty("amount").GetDecimal().Should().Be(amount);
+        payload.RootElement.GetProperty("comments").GetString().Should()
+            .Be("requested_by_customer");
+    }
+
+    [Fact]
+    public async Task RefundPaymentAsync_maps_rejected_response()
+    {
+        var handler = new MockHttpMessageHandler()
+            .RespondWith(HttpStatusCode.OK, VerificationJson())
+            .RespondWith(HttpStatusCode.BadRequest,
+                """{"status":"error","message":"Amount should be above NGN100","data":null}""");
+        var gateway = CreateGateway(new MockHttpClientFactory(handler));
+
+        var result = await gateway.RefundPaymentAsync(PaymentRequestFactory.BuildRefund());
+
+        result.Success.Should().BeFalse();
+        result.Status.Should().Be(PaymentStatus.Failed);
+        result.Message.Should().Be("Amount should be above NGN100");
+    }
+
+    [Fact]
+    public async Task RefundPaymentAsync_maps_malformed_response_without_throwing()
+    {
+        var handler = new MockHttpMessageHandler()
+            .RespondWith(HttpStatusCode.OK, VerificationJson())
+            .RespondWith(HttpStatusCode.OK, "not-json", "text/plain");
+        var gateway = CreateGateway(new MockHttpClientFactory(handler));
+
+        var result = await gateway.RefundPaymentAsync(PaymentRequestFactory.BuildRefund());
+
+        result.Success.Should().BeFalse();
+        result.Status.Should().Be(PaymentStatus.Failed);
+        result.Message.Should().Contain("invalid response");
+    }
+
+    [Fact]
+    public async Task RefundPaymentAsync_maps_timeout_without_throwing()
+    {
+        var gateway = CreateGateway(new StubHttpClientFactory(
+            new TimeoutHandler(VerificationJson())));
+
+        var result = await gateway.RefundPaymentAsync(PaymentRequestFactory.BuildRefund());
+
+        result.Success.Should().BeFalse();
+        result.Status.Should().Be(PaymentStatus.Failed);
+        result.Message.Should().Contain("timed out");
+    }
+
+    [Fact]
+    public async Task RefundPaymentAsync_rejects_amount_above_verified_payment()
+    {
+        var handler = new MockHttpMessageHandler()
+            .RespondWith(HttpStatusCode.OK, VerificationJson(amount: 500));
+        var gateway = CreateGateway(new MockHttpClientFactory(handler));
+
+        var result = await gateway.RefundPaymentAsync(
+            PaymentRequestFactory.BuildRefund(value => value.Amount = 501));
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("exceeds");
+        handler.Requests.Should().ContainSingle();
+    }
+
+    private static FlutterwaveGateway CreateGateway(IHttpClientFactory factory)
+    {
+        var config = new PaymentGatewayConfig
+        {
+            FlutterwaveConfig = new FlutterwaveConfig { SecretKey = "FLW_TEST_SECRET" }
+        };
+        return new FlutterwaveGateway(
+            Options.Create(config),
+            NullLogger<FlutterwaveGateway>.Instance,
+            factory);
+    }
+
+    private static string VerificationJson(decimal amount = 5000) => JsonSerializer.Serialize(
+        new
+        {
+            status = "success",
+            message = "Transaction fetched",
+            data = new
+            {
+                id = 987654,
+                tx_ref = "FLW_MERCHANT_REF",
+                amount,
+                currency = "NGN",
+                status = "successful"
+            }
+        });
+
+    private static string RefundJson(decimal amount, string status) => JsonSerializer.Serialize(
+        new
+        {
+            status = "success",
+            message = "Transaction refund initiated",
+            data = new
+            {
+                id = 75923,
+                flw_ref = "URF_REFUND_123",
+                amount_refunded = amount,
+                status,
+                created_at = "2026-07-18T03:00:00Z"
+            }
+        });
+
+    private sealed class StubHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name = "") => new(handler);
+    }
+
+    private sealed class TimeoutHandler(string verificationJson) : HttpMessageHandler
+    {
+        private int _requestCount;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            _requestCount++;
+            if (_requestCount == 1)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(verificationJson)
+                });
+            }
+
+            throw new TaskCanceledException("The request timed out");
+        }
+    }
+}

--- a/PayBridge.SDK/Gateways/FlutterwaveGateway.cs
+++ b/PayBridge.SDK/Gateways/FlutterwaveGateway.cs
@@ -11,11 +11,11 @@ using System.Text;
 using System.Text.Json;
 
 namespace PayBridge.SDK;
+
 public class FlutterwaveGateway : IPaymentGateway
 {
     private readonly PaymentGatewayConfig _config;
     private readonly HttpClient _httpClient;
-    private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<FlutterwaveGateway> _logger;
     private readonly string _baseUrl = "https://api.flutterwave.com";
     public FlutterwaveGateway(IOptions<PaymentGatewayConfig> config, ILogger<FlutterwaveGateway> logger, IHttpClientFactory httpClientFactory)
@@ -27,8 +27,7 @@ public class FlutterwaveGateway : IPaymentGateway
         }
         _logger = logger;
 
-        _httpClientFactory = httpClientFactory;
-        _httpClient = _httpClientFactory.CreateClient();
+        _httpClient = httpClientFactory.CreateClient();
         _httpClient.BaseAddress = new Uri(_baseUrl);
         _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _config.FlutterwaveConfig.SecretKey);
@@ -123,9 +122,131 @@ public class FlutterwaveGateway : IPaymentGateway
 
     }
 
-    public Task<RefundResponse> RefundPaymentAsync(RefundRequest request)
+    public async Task<RefundResponse> RefundPaymentAsync(RefundRequest request)
     {
-        throw new NotImplementedException();
+        ArgumentNullException.ThrowIfNull(request);
+        if (string.IsNullOrWhiteSpace(request.TransactionReference))
+        {
+            return FailedRefund(request, "Flutterwave transaction reference is required");
+        }
+
+        if (request.Amount <= 0)
+        {
+            return FailedRefund(request, "Flutterwave refund amount must be greater than zero");
+        }
+
+        try
+        {
+            var encodedReference = Uri.EscapeDataString(request.TransactionReference);
+            using var verificationResponse = await _httpClient.GetAsync(
+                $"/v3/transactions/verify_by_reference?tx_ref={encodedReference}");
+            var verificationBody = await verificationResponse.Content.ReadAsStringAsync();
+
+            using var verificationDocument = JsonDocument.Parse(verificationBody);
+            var verificationRoot = verificationDocument.RootElement;
+            if (!verificationResponse.IsSuccessStatusCode ||
+                !IsSuccessfulRoot(verificationRoot) ||
+                !verificationRoot.TryGetProperty("data", out var transaction) ||
+                !TryGetTransactionId(transaction, out var transactionId))
+            {
+                return FailedRefund(
+                    request,
+                    GetMessage(verificationRoot, "Flutterwave transaction could not be resolved"));
+            }
+
+            var transactionStatus = GetString(transaction, "status");
+            if (!string.Equals(transactionStatus, "successful", StringComparison.OrdinalIgnoreCase))
+            {
+                return FailedRefund(request, "Only successful Flutterwave transactions can be refunded");
+            }
+
+            if (transaction.TryGetProperty("amount", out var transactionAmountElement) &&
+                transactionAmountElement.TryGetDecimal(out var transactionAmount) &&
+                request.Amount > transactionAmount)
+            {
+                return FailedRefund(request, "Refund amount exceeds the Flutterwave transaction amount");
+            }
+
+            var refundPayload = new
+            {
+                amount = request.Amount,
+                comments = string.IsNullOrWhiteSpace(request.Reason)
+                    ? "requested_by_customer"
+                    : request.Reason
+            };
+            using var content = new StringContent(
+                JsonSerializer.Serialize(refundPayload),
+                Encoding.UTF8,
+                "application/json");
+            using var refundResponse = await _httpClient.PostAsync(
+                $"/v3/transactions/{transactionId}/refund",
+                content);
+            var refundBody = await refundResponse.Content.ReadAsStringAsync();
+
+            using var refundDocument = JsonDocument.Parse(refundBody);
+            var root = refundDocument.RootElement;
+            if (!refundResponse.IsSuccessStatusCode ||
+                !IsSuccessfulRoot(root) ||
+                !root.TryGetProperty("data", out var data))
+            {
+                return FailedRefund(request, GetMessage(root, "Flutterwave refund was rejected"));
+            }
+
+            var providerStatus = GetString(data, "status").ToLowerInvariant();
+            var failed = providerStatus is "failed" or "error";
+            var pending = providerStatus is "new" or "pending" or "processing";
+            var responseStatus = failed
+                ? PaymentStatus.Failed
+                : pending
+                    ? PaymentStatus.Pending
+                    : PaymentStatus.Refunded;
+            var refundReference = GetString(data, "flw_ref");
+            if (string.IsNullOrWhiteSpace(refundReference) &&
+                data.TryGetProperty("id", out var refundId))
+            {
+                refundReference = refundId.ToString();
+            }
+
+            var refundType = transaction.TryGetProperty("amount", out var originalAmountElement) &&
+                originalAmountElement.TryGetDecimal(out var originalAmount) &&
+                request.Amount == originalAmount
+                    ? "full"
+                    : "partial";
+
+            return new RefundResponse
+            {
+                Success = !failed,
+                RefundReference = refundReference,
+                TransactionReference = request.TransactionReference,
+                Message = failed
+                    ? GetMessage(root, "Flutterwave refund failed")
+                    : $"Flutterwave {refundType} refund {providerStatus}",
+                Amount = data.TryGetProperty("amount_refunded", out var refundedAmount) &&
+                    refundedAmount.TryGetDecimal(out var parsedAmount)
+                        ? parsedAmount
+                        : request.Amount,
+                Status = responseStatus,
+                RefundDate = TryGetDate(data, "created_at") ?? DateTime.UtcNow
+            };
+        }
+        catch (TaskCanceledException ex)
+        {
+            _logger.LogWarning(ex, "Flutterwave refund request timed out for {Reference}",
+                request.TransactionReference);
+            return FailedRefund(request, "Flutterwave refund request timed out");
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "Flutterwave returned an invalid refund response for {Reference}",
+                request.TransactionReference);
+            return FailedRefund(request, "Flutterwave returned an invalid response");
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Flutterwave refund request failed for {Reference}",
+                request.TransactionReference);
+            return FailedRefund(request, "Flutterwave refund request failed");
+        }
     }
 
     public Task<PaymentMethodResponse> SavePaymentMethodAsync(PaymentMethodRequest request)
@@ -190,4 +311,45 @@ public class FlutterwaveGateway : IPaymentGateway
             };
         }
     }
+
+    private static bool IsSuccessfulRoot(JsonElement root) =>
+        string.Equals(GetString(root, "status"), "success", StringComparison.OrdinalIgnoreCase);
+
+    private static bool TryGetTransactionId(JsonElement data, out string transactionId)
+    {
+        transactionId = data.TryGetProperty("id", out var id) &&
+            id.ValueKind is JsonValueKind.Number or JsonValueKind.String
+                ? id.ToString()
+                : string.Empty;
+        return !string.IsNullOrWhiteSpace(transactionId);
+    }
+
+    private static string GetMessage(JsonElement root, string fallback)
+    {
+        var message = GetString(root, "message");
+        return string.IsNullOrWhiteSpace(message) ? fallback : message;
+    }
+
+    private static string GetString(JsonElement element, string name) =>
+        element.ValueKind == JsonValueKind.Object &&
+        element.TryGetProperty(name, out var value) &&
+        value.ValueKind == JsonValueKind.String
+            ? value.GetString() ?? string.Empty
+            : string.Empty;
+
+    private static DateTime? TryGetDate(JsonElement element, string name) =>
+        element.TryGetProperty(name, out var value) &&
+        value.ValueKind == JsonValueKind.String &&
+        DateTime.TryParse(value.GetString(), out var parsed)
+            ? parsed
+            : null;
+
+    private static RefundResponse FailedRefund(RefundRequest request, string message) => new()
+    {
+        Success = false,
+        TransactionReference = request.TransactionReference,
+        Message = message,
+        Amount = request.Amount,
+        Status = PaymentStatus.Failed
+    };
 }

--- a/docs/flutterwave-refunds.md
+++ b/docs/flutterwave-refunds.md
@@ -1,0 +1,52 @@
+# Flutterwave refunds
+
+PayBridge supports full and partial Flutterwave refunds through Flutterwave's
+v3 transaction refund API.
+
+The SDK accepts the merchant transaction reference (`tx_ref`) used throughout
+PayBridge. Before creating the refund, it queries Flutterwave's
+`verify_by_reference` endpoint and uses the returned numeric `data.id` in:
+
+```text
+POST /v3/transactions/{id}/refund
+```
+
+The amount is sent in the currency's major unit, matching Flutterwave's payment
+and refund APIs. PayBridge always sends an explicit amount:
+
+- an amount equal to the verified transaction amount is a full refund;
+- a smaller amount is a partial refund;
+- an amount greater than the verified transaction is rejected before the refund
+  request is sent.
+
+Flutterwave may return a refund as `new`, `pending`, or `processing`; PayBridge
+maps those accepted asynchronous states to `PaymentStatus.Pending`. Completed or
+succeeded responses map to `PaymentStatus.Refunded`, while provider failures map
+to `PaymentStatus.Failed`.
+
+## Sandbox verification
+
+The integration test is deliberately opt-in because a successful refund consumes
+the refundable balance of its transaction. Configure only sandbox values:
+
+```text
+FLUTTERWAVE_SECRET_KEY
+FLUTTERWAVE_REFUND_TRANSACTION_REFERENCE
+FLUTTERWAVE_REFUND_AMOUNT
+```
+
+`FLUTTERWAVE_REFUND_TRANSACTION_REFERENCE` must identify a dedicated successful
+sandbox payment. Replace the fixture after it has been fully refunded. Never use
+live credentials or a customer transaction.
+
+Run the test with:
+
+```bash
+dotnet test PayBridge.SDK.Test/PayBridge.SDK.Test.csproj \
+  --filter FullyQualifiedName~FlutterwaveRefundIntegrationTests
+```
+
+Official references:
+
+- [Flutterwave refunds guide](https://developer.flutterwave.com/v3.0/docs/refunds)
+- [Flutterwave transaction refund API](https://developer.flutterwave.com/v3.0/reference/transaction-refund)


### PR DESCRIPTION
## Summary

- resolve Flutterwave's numeric transaction `data.id` from PayBridge's merchant `tx_ref` before refunding
- implement full and partial refunds through `POST /v3/transactions/{id}/refund`
- map accepted, pending, completed, rejected, malformed, and timeout outcomes into `RefundResponse`
- reject an amount greater than the verified transaction before sending a refund request
- add mocked contract tests, an opt-in sandbox test, and capability/amount-unit documentation

## Root cause

`FlutterwaveGateway.RefundPaymentAsync` threw `NotImplementedException`. The SDK only retains the merchant transaction reference, while Flutterwave's v3 refund API requires its numeric transaction ID, so the implementation must first query `verify_by_reference`.

## TDD

The six mocked refund tests were written first and observed failing with `NotImplementedException`. They cover:

- full refund with an explicit major-unit amount
- partial decimal refund
- rejected provider response
- malformed response
- HTTP timeout
- amount exceeding the verified payment

An opt-in sandbox test is included for a dedicated completed test transaction.

## Provider contract

Implementation follows Flutterwave's official v3 refund guide and transaction refund reference:

- https://developer.flutterwave.com/v3.0/docs/refunds
- https://developer.flutterwave.com/v3.0/reference/transaction-refund

The remaining `SavePaymentMethodAsync` method is a public member required by `IPaymentGateway`, not the private dead refund helper described in the issue, so it is intentionally outside this PR.

## Validation

- focused tests: 6 passed
- .NET 8 Release build: 0 warnings, 0 errors
- full test suite: 118 passed, 3 skipped sandbox tests, 0 failed
- vulnerable NuGet audit: none found
- changed-file formatting and `git diff --check`: clean

## Sandbox evidence still required

Configure a dedicated successful sandbox fixture using `FLUTTERWAVE_SECRET_KEY`, `FLUTTERWAVE_REFUND_TRANSACTION_REFERENCE`, and `FLUTTERWAVE_REFUND_AMOUNT`, then run `FlutterwaveRefundIntegrationTests`. Because a refund consumes the fixture's refundable balance, the test is deliberately opt-in and this PR references rather than automatically closes the issue.

Refs #57
