### PR TITLE
Persist refunds and prevent cumulative over-refunds

### DIFF
--- a/PayBridge.SDK.Test/Unit/IServiceCollectionExtensionsTests.cs
+++ b/PayBridge.SDK.Test/Unit/IServiceCollectionExtensionsTests.cs
@@ -103,6 +103,20 @@ public class IServiceCollectionExtensionsTests
         provider.GetRequiredService<TimeProvider>().Should().BeSameAs(customTimeProvider);
     }
 
+    [Fact]
+    public void AddPayBridge_RegistersRefundRepository()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddPayBridge(BuildConfiguration([]));
+
+        services.Should().Contain(descriptor =>
+            descriptor.ServiceType == typeof(IRefundRepository) &&
+            descriptor.ImplementationType == typeof(RefundRepository) &&
+            descriptor.Lifetime == ServiceLifetime.Scoped);
+    }
+
     private static IConfiguration BuildConfiguration(Dictionary<string, string?> values)
     {
         return new ConfigurationBuilder()

--- a/PayBridge.SDK.Test/Unit/PaymentServiceRefundTests.cs
+++ b/PayBridge.SDK.Test/Unit/PaymentServiceRefundTests.cs
@@ -17,13 +17,14 @@ public class PaymentServiceRefundTests
     [Fact]
     public async Task RefundPaymentAsync_persists_confirmed_full_refund_and_updates_payment()
     {
+        var providerTimestamp = DateTime.UtcNow.AddMinutes(-5);
         var fixture = CreateFixture(new RefundResponse
         {
             Success = true,
             RefundReference = "provider-refund",
             Amount = 100m,
             Status = PaymentStatus.Refunded,
-            RefundDate = DateTime.UtcNow
+            RefundDate = providerTimestamp
         });
 
         var response = await fixture.Service.RefundPaymentAsync(NewRequest(100m));
@@ -31,7 +32,9 @@ public class PaymentServiceRefundTests
         response.Success.Should().BeTrue();
         fixture.Refund.Status.Should().Be(PaymentStatus.Refunded);
         fixture.Refund.RefundReference.Should().Be("provider-refund");
-        fixture.Refund.ProcessedAt.Should().NotBeNull();
+        fixture.Refund.ProcessedAt.Should().Be(providerTimestamp);
+        fixture.Refunds.Verify(repository =>
+            repository.UpdateAsync(fixture.Refund), Times.Once);
         fixture.Transaction.Status.Should().Be(PaymentStatus.Refunded);
         fixture.Transactions.Verify(repository =>
             repository.UpdateAsync(fixture.Transaction), Times.Once);
@@ -51,6 +54,8 @@ public class PaymentServiceRefundTests
         await fixture.Service.RefundPaymentAsync(NewRequest(100m));
 
         fixture.Refund.Status.Should().Be(PaymentStatus.Pending);
+        fixture.Refunds.Verify(repository =>
+            repository.UpdateAsync(fixture.Refund), Times.Once);
         fixture.Transaction.Status.Should().Be(PaymentStatus.Successful);
         fixture.Transactions.Verify(repository =>
             repository.UpdateAsync(It.IsAny<PaymentTransaction>()), Times.Never);
@@ -72,6 +77,8 @@ public class PaymentServiceRefundTests
         fixture.Refund.Status.Should().Be(PaymentStatus.Failed);
         fixture.Refund.ProcessedAt.Should().NotBeNull();
         fixture.Refund.GatewayResponse.Should().Contain("rejected");
+        fixture.Refunds.Verify(repository =>
+            repository.UpdateAsync(fixture.Refund), Times.Once);
     }
 
     [Fact]
@@ -84,6 +91,8 @@ public class PaymentServiceRefundTests
         await action.Should().ThrowAsync<Exception>();
         fixture.Refund.Status.Should().Be(PaymentStatus.Failed);
         fixture.Refund.ProcessedAt.Should().NotBeNull();
+        fixture.Refunds.Verify(repository =>
+            repository.UpdateAsync(fixture.Refund), Times.Once);
     }
 
     [Fact]

--- a/PayBridge.SDK.Test/Unit/PaymentServiceRefundTests.cs
+++ b/PayBridge.SDK.Test/Unit/PaymentServiceRefundTests.cs
@@ -1,0 +1,184 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using PayBridge.SDK.Application.Dtos;
+using PayBridge.SDK.Application.Dtos.Request;
+using PayBridge.SDK.Dtos.Response;
+using PayBridge.SDK.Entities;
+using PayBridge.SDK.Enums;
+using PayBridge.SDK.Interfaces;
+using Xunit;
+
+namespace PayBridge.SDK.Test.Unit;
+
+[Trait("Category", "Unit")]
+public class PaymentServiceRefundTests
+{
+    [Fact]
+    public async Task RefundPaymentAsync_persists_confirmed_full_refund_and_updates_payment()
+    {
+        var fixture = CreateFixture(new RefundResponse
+        {
+            Success = true,
+            RefundReference = "provider-refund",
+            Amount = 100m,
+            Status = PaymentStatus.Refunded,
+            RefundDate = DateTime.UtcNow
+        });
+
+        var response = await fixture.Service.RefundPaymentAsync(NewRequest(100m));
+
+        response.Success.Should().BeTrue();
+        fixture.Refund.Status.Should().Be(PaymentStatus.Refunded);
+        fixture.Refund.RefundReference.Should().Be("provider-refund");
+        fixture.Refund.ProcessedAt.Should().NotBeNull();
+        fixture.Transaction.Status.Should().Be(PaymentStatus.Refunded);
+        fixture.Transactions.Verify(repository =>
+            repository.UpdateAsync(fixture.Transaction), Times.Once);
+    }
+
+    [Fact]
+    public async Task RefundPaymentAsync_keeps_payment_successful_while_provider_refund_is_pending()
+    {
+        var fixture = CreateFixture(new RefundResponse
+        {
+            Success = true,
+            RefundReference = "pending-refund",
+            Amount = 100m,
+            Status = PaymentStatus.Pending
+        });
+
+        await fixture.Service.RefundPaymentAsync(NewRequest(100m));
+
+        fixture.Refund.Status.Should().Be(PaymentStatus.Pending);
+        fixture.Transaction.Status.Should().Be(PaymentStatus.Successful);
+        fixture.Transactions.Verify(repository =>
+            repository.UpdateAsync(It.IsAny<PaymentTransaction>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RefundPaymentAsync_persists_rejected_provider_attempt_as_failed()
+    {
+        var fixture = CreateFixture(new RefundResponse
+        {
+            Success = false,
+            Message = "rejected",
+            Status = PaymentStatus.Failed
+        });
+
+        var response = await fixture.Service.RefundPaymentAsync(NewRequest(25m));
+
+        response.Success.Should().BeFalse();
+        fixture.Refund.Status.Should().Be(PaymentStatus.Failed);
+        fixture.Refund.ProcessedAt.Should().NotBeNull();
+        fixture.Refund.GatewayResponse.Should().Contain("rejected");
+    }
+
+    [Fact]
+    public async Task RefundPaymentAsync_marks_attempt_failed_when_gateway_throws()
+    {
+        var fixture = CreateFixture(exception: new HttpRequestException("network unavailable"));
+
+        var action = () => fixture.Service.RefundPaymentAsync(NewRequest(25m));
+
+        await action.Should().ThrowAsync<Exception>();
+        fixture.Refund.Status.Should().Be(PaymentStatus.Failed);
+        fixture.Refund.ProcessedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task RefundPaymentAsync_rejects_when_balance_cannot_be_reserved()
+    {
+        var fixture = CreateFixture(new RefundResponse { Success = true });
+        fixture.Refunds
+            .Setup(repository => repository.TryReserveAsync(
+                It.IsAny<RefundTransaction>(),
+                fixture.Transaction.Amount))
+            .ReturnsAsync(false);
+
+        var action = () => fixture.Service.RefundPaymentAsync(NewRequest(60m));
+
+        await action.Should().ThrowAsync<Exception>()
+            .WithMessage("*refundable balance*");
+        fixture.Gateway.Verify(gateway =>
+            gateway.RefundPaymentAsync(It.IsAny<RefundRequest>()), Times.Never);
+    }
+
+    private static Fixture CreateFixture(
+        RefundResponse? response = null,
+        Exception? exception = null)
+    {
+        var transaction = new PaymentTransaction
+        {
+            TransactionReference = "PAYMENT-1",
+            Amount = 100m,
+            Currency = "NGN",
+            Status = PaymentStatus.Successful,
+            Gateway = PaymentGatewayType.Flutterwave
+        };
+        var transactions = new Mock<ITransactionRepository>();
+        transactions.Setup(repository => repository.GetByReferenceAsync("PAYMENT-1"))
+            .ReturnsAsync(transaction);
+        transactions.Setup(repository => repository.UpdateAsync(transaction))
+            .ReturnsAsync(transaction);
+
+        RefundTransaction? capturedRefund = null;
+        var refunds = new Mock<IRefundRepository>();
+        refunds.Setup(repository => repository.TryReserveAsync(
+                It.IsAny<RefundTransaction>(),
+                transaction.Amount))
+            .Callback<RefundTransaction, decimal>((refund, _) => capturedRefund = refund)
+            .ReturnsAsync(true);
+        refunds.Setup(repository => repository.UpdateAsync(It.IsAny<RefundTransaction>()))
+            .ReturnsAsync((RefundTransaction refund) => refund);
+        refunds.Setup(repository => repository.GetByPaymentReferenceAsync("PAYMENT-1"))
+            .ReturnsAsync(() => capturedRefund is null
+                ? []
+                : [capturedRefund]);
+
+        var gateway = new Mock<IPaymentGateway>();
+        gateway.SetupGet(item => item.GatewayType).Returns(PaymentGatewayType.Flutterwave);
+        if (exception is not null)
+        {
+            gateway.Setup(item => item.RefundPaymentAsync(It.IsAny<RefundRequest>()))
+                .ThrowsAsync(exception);
+        }
+        else
+        {
+            gateway.Setup(item => item.RefundPaymentAsync(It.IsAny<RefundRequest>()))
+                .ReturnsAsync(response!);
+        }
+
+        var service = new PaymentService(
+            transactions.Object,
+            refunds.Object,
+            [gateway.Object],
+            NullLogger<PaymentService>.Instance,
+            new PaymentGatewayConfig());
+        return new Fixture(
+            service,
+            transaction,
+            transactions,
+            refunds,
+            gateway,
+            () => capturedRefund!);
+    }
+
+    private static RefundRequest NewRequest(decimal amount) => new()
+    {
+        TransactionReference = "PAYMENT-1",
+        Amount = amount,
+        Reason = "requested_by_customer"
+    };
+
+    private sealed record Fixture(
+        PaymentService Service,
+        PaymentTransaction Transaction,
+        Mock<ITransactionRepository> Transactions,
+        Mock<IRefundRepository> Refunds,
+        Mock<IPaymentGateway> Gateway,
+        Func<RefundTransaction> GetRefund)
+    {
+        public RefundTransaction Refund => GetRefund();
+    }
+}

--- a/PayBridge.SDK.Test/Unit/RefundRepositoryTests.cs
+++ b/PayBridge.SDK.Test/Unit/RefundRepositoryTests.cs
@@ -66,6 +66,21 @@ public class RefundRepositoryTests
             .Should().BeTrue();
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task TryReserveAsync_rejects_non_positive_amounts(decimal amount)
+    {
+        await using var database = await RefundDatabase.CreateAsync();
+        await using var context = database.CreateContext();
+        var repository = CreateRepository(context);
+
+        var action = () => repository.TryReserveAsync(NewRefund("invalid", amount), 100m);
+
+        await action.Should().ThrowAsync<ArgumentOutOfRangeException>()
+            .WithParameterName("amount");
+    }
+
     [Fact]
     public async Task Concurrent_reservations_cannot_exceed_captured_amount()
     {

--- a/PayBridge.SDK.Test/Unit/RefundRepositoryTests.cs
+++ b/PayBridge.SDK.Test/Unit/RefundRepositoryTests.cs
@@ -1,0 +1,158 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using PayBridge.SDK.Entities;
+using PayBridge.SDK.Enums;
+using Xunit;
+
+namespace PayBridge.SDK.Test.Unit;
+
+[Trait("Category", "Unit")]
+public class RefundRepositoryTests
+{
+    [Fact]
+    public async Task DbContext_model_defines_refund_reservation_index()
+    {
+        await using var database = await RefundDatabase.CreateAsync();
+        await using var context = database.CreateContext();
+
+        var entity = context.Model.FindEntityType(typeof(RefundTransaction));
+        var index = entity!.GetIndexes().Single(item =>
+            item.Properties.Select(property => property.Name).SequenceEqual(
+                [nameof(RefundTransaction.PaymentTransactionReference),
+                 nameof(RefundTransaction.Status)]));
+
+        index.GetDatabaseName().Should()
+            .Be("IX_Refunds_PaymentTransactionReference_Status");
+    }
+
+    [Fact]
+    public async Task TryReserveAsync_rejects_cumulative_pending_and_refunded_amounts()
+    {
+        await using var database = await RefundDatabase.CreateAsync();
+        await database.SeedPaymentAsync(100m);
+
+        await using (var context = database.CreateContext())
+        {
+            var repository = CreateRepository(context);
+            (await repository.TryReserveAsync(NewRefund("first", 60m), 100m)).Should().BeTrue();
+            var completed = await repository.GetByReferenceAsync("first");
+            completed!.Status = PaymentStatus.Refunded;
+            await repository.UpdateAsync(completed);
+        }
+
+        await using (var context = database.CreateContext())
+        {
+            var repository = CreateRepository(context);
+            (await repository.TryReserveAsync(NewRefund("second", 40m), 100m)).Should().BeTrue();
+            (await repository.TryReserveAsync(NewRefund("third", 0.01m), 100m)).Should().BeFalse();
+        }
+    }
+
+    [Fact]
+    public async Task TryReserveAsync_does_not_count_failed_attempts()
+    {
+        await using var database = await RefundDatabase.CreateAsync();
+        await database.SeedPaymentAsync(100m);
+
+        await using var context = database.CreateContext();
+        var repository = CreateRepository(context);
+        var failed = NewRefund("failed", 100m);
+        failed.Status = PaymentStatus.Failed;
+        await repository.CreateAsync(failed);
+
+        (await repository.TryReserveAsync(NewRefund("replacement", 100m), 100m))
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Concurrent_reservations_cannot_exceed_captured_amount()
+    {
+        await using var database = await RefundDatabase.CreateAsync();
+        await database.SeedPaymentAsync(100m);
+
+        var attempts = Enumerable.Range(0, 8).Select(async index =>
+        {
+            await using var context = database.CreateContext();
+            var repository = CreateRepository(context);
+            return await repository.TryReserveAsync(NewRefund($"refund-{index}", 60m), 100m);
+        });
+
+        var results = await Task.WhenAll(attempts);
+
+        results.Count(result => result).Should().Be(1);
+        await using var assertionContext = database.CreateContext();
+        var reservedAmounts = await assertionContext.Refunds
+            .Where(refund => refund.Status == PaymentStatus.Pending ||
+                refund.Status == PaymentStatus.Refunded)
+            .Select(refund => refund.Amount)
+            .ToListAsync();
+        var reserved = reservedAmounts.Sum();
+        reserved.Should().BeLessThanOrEqualTo(100m);
+    }
+
+    private static RefundRepository CreateRepository(PayBridgeDbContext context) =>
+        new(context, NullLogger<RefundRepository>.Instance);
+
+    private static RefundTransaction NewRefund(string id, decimal amount) => new()
+    {
+        Id = id,
+        RefundReference = id,
+        PaymentTransactionReference = "PAYMENT-1",
+        Amount = amount,
+        Currency = "NGN",
+        Reason = "requested_by_customer",
+        Gateway = PaymentGatewayType.Flutterwave,
+        Status = PaymentStatus.Pending,
+        CreatedAt = DateTime.UtcNow
+    };
+
+    private sealed class RefundDatabase : IAsyncDisposable
+    {
+        private readonly SqliteConnection _keepAlive;
+        private readonly DbContextOptions<PayBridgeDbContext> _options;
+
+        private RefundDatabase(
+            SqliteConnection keepAlive,
+            DbContextOptions<PayBridgeDbContext> options)
+        {
+            _keepAlive = keepAlive;
+            _options = options;
+        }
+
+        public static async Task<RefundDatabase> CreateAsync()
+        {
+            var name = $"refund-{Guid.NewGuid():N}";
+            var connectionString = $"Data Source={name};Mode=Memory;Cache=Shared;Default Timeout=5";
+            var keepAlive = new SqliteConnection(connectionString);
+            await keepAlive.OpenAsync();
+            var options = new DbContextOptionsBuilder<PayBridgeDbContext>()
+                .UseSqlite(connectionString)
+                .Options;
+            await using var context = new PayBridgeDbContext(options);
+            await context.Database.EnsureCreatedAsync();
+            return new RefundDatabase(keepAlive, options);
+        }
+
+        public PayBridgeDbContext CreateContext() => new(_options);
+
+        public async Task SeedPaymentAsync(decimal amount)
+        {
+            await using var context = CreateContext();
+            context.Transactions.Add(new PaymentTransaction
+            {
+                Id = "payment-id",
+                TransactionReference = "PAYMENT-1",
+                Amount = amount,
+                Currency = "NGN",
+                Status = PaymentStatus.Successful,
+                Gateway = PaymentGatewayType.Flutterwave,
+                CreatedAt = DateTime.UtcNow
+            });
+            await context.SaveChangesAsync();
+        }
+
+        public async ValueTask DisposeAsync() => await _keepAlive.DisposeAsync();
+    }
+}

--- a/PayBridge.SDK/Externsions/IServiceCollectionExtensions.cs
+++ b/PayBridge.SDK/Externsions/IServiceCollectionExtensions.cs
@@ -131,6 +131,7 @@ public static class IServiceCollectionExtensions
         // Register core services
         services.AddScoped<IPaymentService, PaymentService>();
         services.AddScoped<ITransactionRepository, TransactionRepository>();
+        services.AddScoped<IRefundRepository, RefundRepository>();
         services.AddScoped<PaymentGatewayFactory>();
         services.TryAddSingleton(TimeProvider.System);
         services.TryAddSingleton<IWebhookSignatureVerifier, WebhookSignatureVerifier>();

--- a/PayBridge.SDK/Interfaces/IRefundRepository.cs
+++ b/PayBridge.SDK/Interfaces/IRefundRepository.cs
@@ -1,6 +1,7 @@
 ﻿using PayBridge.SDK.Entities;
 
 namespace PayBridge.SDK.Interfaces;
+
 public interface IRefundRepository
 {
     /// <summary>
@@ -9,9 +10,14 @@ public interface IRefundRepository
     Task<RefundTransaction> CreateAsync(RefundTransaction refund);
 
     /// <summary>
+    /// Atomically reserves refundable balance by inserting a pending refund.
+    /// </summary>
+    Task<bool> TryReserveAsync(RefundTransaction refund, decimal capturedAmount);
+
+    /// <summary>
     /// Gets a refund by its reference
     /// </summary>
-    Task<RefundTransaction> GetByReferenceAsync(string reference);
+    Task<RefundTransaction?> GetByReferenceAsync(string reference);
 
     /// <summary>
     /// Gets refunds for a specific payment transaction

--- a/PayBridge.SDK/Migrations/20260718074022_AddRefundReservationIndex.Designer.cs
+++ b/PayBridge.SDK/Migrations/20260718074022_AddRefundReservationIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using PayBridge.SDK;
 
@@ -11,9 +12,11 @@ using PayBridge.SDK;
 namespace PayBridge.SDK.Migrations
 {
     [DbContext(typeof(PayBridgeDbContext))]
-    partial class PayBridgeDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260718074022_AddRefundReservationIndex")]
+    partial class AddRefundReservationIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/PayBridge.SDK/Migrations/20260718074022_AddRefundReservationIndex.cs
+++ b/PayBridge.SDK/Migrations/20260718074022_AddRefundReservationIndex.cs
@@ -10,13 +10,14 @@ namespace PayBridge.SDK.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            var (boundedType, unboundedType) = GetProviderColumnTypes();
             migrationBuilder.AlterColumn<string>(
                 name: "PaymentTransactionReference",
                 table: "Refunds",
-                type: "nvarchar(450)",
+                type: boundedType,
                 nullable: false,
                 oldClrType: typeof(string),
-                oldType: "nvarchar(max)");
+                oldType: unboundedType);
 
             migrationBuilder.CreateIndex(
                 name: "IX_Refunds_PaymentTransactionReference_Status",
@@ -31,13 +32,34 @@ namespace PayBridge.SDK.Migrations
                 name: "IX_Refunds_PaymentTransactionReference_Status",
                 table: "Refunds");
 
+            var (boundedType, unboundedType) = GetProviderColumnTypes();
             migrationBuilder.AlterColumn<string>(
                 name: "PaymentTransactionReference",
                 table: "Refunds",
-                type: "nvarchar(max)",
+                type: unboundedType,
                 nullable: false,
                 oldClrType: typeof(string),
-                oldType: "nvarchar(450)");
+                oldType: boundedType);
+        }
+
+        private (string Bounded, string Unbounded) GetProviderColumnTypes()
+        {
+            if (ActiveProvider.Contains("Npgsql"))
+            {
+                return ("character varying(450)", "text");
+            }
+
+            if (ActiveProvider.Contains("MySql"))
+            {
+                return ("varchar(450)", "longtext");
+            }
+
+            if (ActiveProvider.Contains("Sqlite"))
+            {
+                return ("TEXT", "TEXT");
+            }
+
+            return ("nvarchar(450)", "nvarchar(max)");
         }
     }
 }

--- a/PayBridge.SDK/Migrations/20260718074022_AddRefundReservationIndex.cs
+++ b/PayBridge.SDK/Migrations/20260718074022_AddRefundReservationIndex.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PayBridge.SDK.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRefundReservationIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "PaymentTransactionReference",
+                table: "Refunds",
+                type: "nvarchar(450)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Refunds_PaymentTransactionReference_Status",
+                table: "Refunds",
+                columns: new[] { "PaymentTransactionReference", "Status" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Refunds_PaymentTransactionReference_Status",
+                table: "Refunds");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "PaymentTransactionReference",
+                table: "Refunds",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(450)");
+        }
+    }
+}

--- a/PayBridge.SDK/Persistence/PayBridgeDbContext.cs
+++ b/PayBridge.SDK/Persistence/PayBridgeDbContext.cs
@@ -10,4 +10,10 @@ public class PayBridgeDbContext : DbContext
 
     public DbSet<PaymentTransaction> Transactions { get; set; }
     public DbSet<RefundTransaction> Refunds { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<RefundTransaction>()
+            .HasIndex(refund => new { refund.PaymentTransactionReference, refund.Status });
+    }
 }

--- a/PayBridge.SDK/Repositories/RefundRepository.cs
+++ b/PayBridge.SDK/Repositories/RefundRepository.cs
@@ -11,7 +11,8 @@ public sealed class RefundRepository(
     PayBridgeDbContext dbContext,
     ILogger<RefundRepository> logger) : IRefundRepository
 {
-    private static readonly SemaphoreSlim ReservationLock = new(1, 1);
+    private static readonly object ReservationLocksGate = new();
+    private static readonly Dictionary<string, ReservationLock> ReservationLocks = [];
     private readonly PayBridgeDbContext _dbContext =
         dbContext ?? throw new ArgumentNullException(nameof(dbContext));
     private readonly ILogger<RefundRepository> _logger =
@@ -31,41 +32,53 @@ public sealed class RefundRepository(
         decimal capturedAmount)
     {
         ArgumentNullException.ThrowIfNull(refund);
+        if (refund.Amount <= 0)
+        {
+            throw new ArgumentOutOfRangeException("amount", refund.Amount,
+                "Refund amount must be positive.");
+        }
+
         if (capturedAmount <= 0)
         {
             throw new ArgumentOutOfRangeException(nameof(capturedAmount));
         }
 
-        await ReservationLock.WaitAsync();
+        var reservationLock = AcquireReservationLock(refund.PaymentTransactionReference);
+        await reservationLock.Semaphore.WaitAsync();
         try
         {
-            await using var transaction = await _dbContext.Database.BeginTransactionAsync(
-                IsolationLevel.Serializable);
-            var reservedAmounts = await _dbContext.Refunds
-                .Where(item =>
-                    item.PaymentTransactionReference == refund.PaymentTransactionReference &&
-                    (item.Status == PaymentStatus.Pending ||
-                     item.Status == PaymentStatus.Refunded))
-                .Select(item => item.Amount)
-                .ToListAsync();
-            var reservedAmount = reservedAmounts.Sum();
-
-            if (reservedAmount + refund.Amount > capturedAmount)
+            var strategy = _dbContext.Database.CreateExecutionStrategy();
+            return await strategy.ExecuteAsync(async () =>
             {
-                await transaction.RollbackAsync();
-                return false;
-            }
+                await using var transaction = await _dbContext.Database.BeginTransactionAsync(
+                    IsolationLevel.Serializable);
+                var reservedAmounts = await _dbContext.Refunds
+                    .Where(item =>
+                        item.PaymentTransactionReference == refund.PaymentTransactionReference &&
+                        (item.Status == PaymentStatus.Pending ||
+                         item.Status == PaymentStatus.Refunded))
+                    .Select(item => item.Amount)
+                    .ToListAsync();
+                var reservedAmount = reservedAmounts.Sum();
 
-            refund.Status = PaymentStatus.Pending;
-            PrepareForInsert(refund);
-            await _dbContext.Refunds.AddAsync(refund);
-            await _dbContext.SaveChangesAsync();
-            await transaction.CommitAsync();
-            return true;
+                if (reservedAmount + refund.Amount > capturedAmount)
+                {
+                    await transaction.RollbackAsync();
+                    return false;
+                }
+
+                refund.Status = PaymentStatus.Pending;
+                PrepareForInsert(refund);
+                await _dbContext.Refunds.AddAsync(refund);
+                await _dbContext.SaveChangesAsync();
+                await transaction.CommitAsync();
+                return true;
+            });
         }
         finally
         {
-            ReservationLock.Release();
+            reservationLock.Semaphore.Release();
+            ReleaseReservationLock(refund.PaymentTransactionReference, reservationLock);
         }
     }
 
@@ -110,5 +123,41 @@ public sealed class RefundRepository(
         {
             refund.CreatedAt = DateTime.UtcNow;
         }
+    }
+
+    private static ReservationLock AcquireReservationLock(string paymentReference)
+    {
+        lock (ReservationLocksGate)
+        {
+            if (!ReservationLocks.TryGetValue(paymentReference, out var reservationLock))
+            {
+                reservationLock = new ReservationLock();
+                ReservationLocks.Add(paymentReference, reservationLock);
+            }
+
+            reservationLock.Users++;
+            return reservationLock;
+        }
+    }
+
+    private static void ReleaseReservationLock(
+        string paymentReference,
+        ReservationLock reservationLock)
+    {
+        lock (ReservationLocksGate)
+        {
+            reservationLock.Users--;
+            if (reservationLock.Users == 0)
+            {
+                ReservationLocks.Remove(paymentReference);
+                reservationLock.Semaphore.Dispose();
+            }
+        }
+    }
+
+    private sealed class ReservationLock
+    {
+        public SemaphoreSlim Semaphore { get; } = new(1, 1);
+        public int Users { get; set; }
     }
 }

--- a/PayBridge.SDK/Repositories/RefundRepository.cs
+++ b/PayBridge.SDK/Repositories/RefundRepository.cs
@@ -1,0 +1,114 @@
+using System.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using PayBridge.SDK.Entities;
+using PayBridge.SDK.Enums;
+using PayBridge.SDK.Interfaces;
+
+namespace PayBridge.SDK;
+
+public sealed class RefundRepository(
+    PayBridgeDbContext dbContext,
+    ILogger<RefundRepository> logger) : IRefundRepository
+{
+    private static readonly SemaphoreSlim ReservationLock = new(1, 1);
+    private readonly PayBridgeDbContext _dbContext =
+        dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+    private readonly ILogger<RefundRepository> _logger =
+        logger ?? throw new ArgumentNullException(nameof(logger));
+
+    public async Task<RefundTransaction> CreateAsync(RefundTransaction refund)
+    {
+        ArgumentNullException.ThrowIfNull(refund);
+        PrepareForInsert(refund);
+        await _dbContext.Refunds.AddAsync(refund);
+        await _dbContext.SaveChangesAsync();
+        return refund;
+    }
+
+    public async Task<bool> TryReserveAsync(
+        RefundTransaction refund,
+        decimal capturedAmount)
+    {
+        ArgumentNullException.ThrowIfNull(refund);
+        if (capturedAmount <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(capturedAmount));
+        }
+
+        await ReservationLock.WaitAsync();
+        try
+        {
+            await using var transaction = await _dbContext.Database.BeginTransactionAsync(
+                IsolationLevel.Serializable);
+            var reservedAmounts = await _dbContext.Refunds
+                .Where(item =>
+                    item.PaymentTransactionReference == refund.PaymentTransactionReference &&
+                    (item.Status == PaymentStatus.Pending ||
+                     item.Status == PaymentStatus.Refunded))
+                .Select(item => item.Amount)
+                .ToListAsync();
+            var reservedAmount = reservedAmounts.Sum();
+
+            if (reservedAmount + refund.Amount > capturedAmount)
+            {
+                await transaction.RollbackAsync();
+                return false;
+            }
+
+            refund.Status = PaymentStatus.Pending;
+            PrepareForInsert(refund);
+            await _dbContext.Refunds.AddAsync(refund);
+            await _dbContext.SaveChangesAsync();
+            await transaction.CommitAsync();
+            return true;
+        }
+        finally
+        {
+            ReservationLock.Release();
+        }
+    }
+
+    public async Task<RefundTransaction?> GetByReferenceAsync(string reference)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(reference);
+        return await _dbContext.Refunds
+            .FirstOrDefaultAsync(refund => refund.RefundReference == reference);
+    }
+
+    public async Task<IEnumerable<RefundTransaction>> GetByPaymentReferenceAsync(
+        string paymentReference)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(paymentReference);
+        return await _dbContext.Refunds
+            .Where(refund => refund.PaymentTransactionReference == paymentReference)
+            .OrderByDescending(refund => refund.CreatedAt)
+            .ToListAsync();
+    }
+
+    public async Task<RefundTransaction> UpdateAsync(RefundTransaction refund)
+    {
+        ArgumentNullException.ThrowIfNull(refund);
+        _dbContext.Refunds.Update(refund);
+        await _dbContext.SaveChangesAsync();
+        return refund;
+    }
+
+    private static void PrepareForInsert(RefundTransaction refund)
+    {
+        if (string.IsNullOrWhiteSpace(refund.Id))
+        {
+            refund.Id = Guid.NewGuid().ToString("N");
+        }
+
+        if (string.IsNullOrWhiteSpace(refund.RefundReference))
+        {
+            refund.RefundReference = refund.Id;
+        }
+
+        if (refund.CreatedAt == default)
+        {
+            refund.CreatedAt = DateTime.UtcNow;
+        }
+    }
+}

--- a/PayBridge.SDK/Services/PaymentService.cs
+++ b/PayBridge.SDK/Services/PaymentService.cs
@@ -15,17 +15,20 @@ namespace PayBridge.SDK;
 public class PaymentService : IPaymentService
 {
     private readonly ITransactionRepository _transactionRepository;
+    private readonly IRefundRepository _refundRepository;
     private readonly Dictionary<PaymentGatewayType, IPaymentGateway> _gateways;
     private readonly ILogger<PaymentService> _logger;
     private readonly PaymentGatewayConfig _config;
 
     public PaymentService(
         ITransactionRepository transactionRepository,
+        IRefundRepository refundRepository,
         IEnumerable<IPaymentGateway> gateways,  // Inject all gateways directly
         ILogger<PaymentService> logger,
         PaymentGatewayConfig config)
     {
         _transactionRepository = transactionRepository ?? throw new ArgumentNullException(nameof(transactionRepository));
+        _refundRepository = refundRepository ?? throw new ArgumentNullException(nameof(refundRepository));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _config = config ?? throw new ArgumentNullException(nameof(config));
 
@@ -190,14 +193,6 @@ public class PaymentService : IPaymentService
             throw new PaymentGatewayException($"Transaction not in refundable state: {transaction.Status}");
         }
 
-        // Verify refund amount does not exceed transaction amount
-        if (request.Amount > transaction.Amount)
-        {
-            _logger.LogError("Refund amount exceeds transaction amount: {RefundAmount} > {TransactionAmount}",
-                request.Amount, transaction.Amount);
-            throw new PaymentGatewayException($"Refund amount exceeds transaction amount");
-        }
-
         PaymentGatewayType selectedGateway = transaction.Gateway;
         if (!_gateways.ContainsKey(selectedGateway))
         {
@@ -205,32 +200,71 @@ public class PaymentService : IPaymentService
             throw new PaymentGatewayException($"Gateway {selectedGateway} is not configured");
         }
 
+        var refund = new RefundTransaction
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            PaymentTransactionReference = request.TransactionReference,
+            Amount = request.Amount,
+            Currency = transaction.Currency,
+            Reason = request.Reason,
+            Status = PaymentStatus.Pending,
+            Gateway = selectedGateway,
+            CreatedAt = DateTime.UtcNow
+        };
+        refund.RefundReference = refund.Id;
+
+        if (!await _refundRepository.TryReserveAsync(refund, transaction.Amount))
+        {
+            _logger.LogWarning(
+                "Refund amount exceeds refundable balance for {Reference}",
+                request.TransactionReference);
+            throw new PaymentGatewayException("Refund amount exceeds refundable balance");
+        }
+
+        RefundResponse response;
         try
         {
-            var response = await _gateways[selectedGateway].RefundPaymentAsync(request);
-
-            _logger.LogInformation("Refund processing {Status}: {Reference}, Refund Reference: {RefundReference}",
-                response.Success ? "successful" : "failed", request.TransactionReference, response.RefundReference);
-
-            if (response.Success)
-            {
-                // Update transaction status if full refund
-                if (request.Amount >= transaction.Amount)
-                {
-                    transaction.Status = PaymentStatus.Refunded;
-                    await _transactionRepository.UpdateAsync(transaction);
-                }
-
-                // TODO: Save refund record to refund repository if implemented
-            }
-
-            return response;
+            response = await _gateways[selectedGateway].RefundPaymentAsync(request);
         }
         catch (Exception ex)
         {
+            refund.Status = PaymentStatus.Failed;
+            refund.ProcessedAt = DateTime.UtcNow;
+            refund.GatewayResponse = JsonSerializer.Serialize(new
+            {
+                ErrorType = ex.GetType().Name
+            });
+            await _refundRepository.UpdateAsync(refund);
             _logger.LogError(ex, "Refund processing failed with {Gateway}", selectedGateway);
             throw new PaymentGatewayException($"Refund processing failed with {selectedGateway}", ex);
         }
+
+        _logger.LogInformation("Refund processing {Status}: {Reference}, Refund Reference: {RefundReference}",
+            response.Success ? "successful" : "failed", request.TransactionReference, response.RefundReference);
+
+        refund.RefundReference = string.IsNullOrWhiteSpace(response.RefundReference)
+            ? refund.Id
+            : response.RefundReference;
+        refund.Status = response.Success ? response.Status : PaymentStatus.Failed;
+        refund.ProcessedAt = refund.Status == PaymentStatus.Pending ? null : DateTime.UtcNow;
+        refund.GatewayResponse = JsonSerializer.Serialize(response);
+        await _refundRepository.UpdateAsync(refund);
+
+        if (refund.Status == PaymentStatus.Refunded)
+        {
+            var refunds = await _refundRepository.GetByPaymentReferenceAsync(
+                request.TransactionReference);
+            var confirmedAmount = refunds
+                .Where(item => item.Status == PaymentStatus.Refunded)
+                .Sum(item => item.Amount);
+            if (confirmedAmount >= transaction.Amount)
+            {
+                transaction.Status = PaymentStatus.Refunded;
+                await _transactionRepository.UpdateAsync(transaction);
+            }
+        }
+
+        return response;
     }
 
     private PaymentGatewayType SelectBestGateway(PaymentRequest request)

--- a/PayBridge.SDK/Services/PaymentService.cs
+++ b/PayBridge.SDK/Services/PaymentService.cs
@@ -246,7 +246,9 @@ public class PaymentService : IPaymentService
             ? refund.Id
             : response.RefundReference;
         refund.Status = response.Success ? response.Status : PaymentStatus.Failed;
-        refund.ProcessedAt = refund.Status == PaymentStatus.Pending ? null : DateTime.UtcNow;
+        refund.ProcessedAt = refund.Status == PaymentStatus.Pending
+            ? null
+            : response.RefundDate == default ? DateTime.UtcNow : response.RefundDate;
         refund.GatewayResponse = JsonSerializer.Serialize(response);
         await _refundRepository.UpdateAsync(refund);
 

--- a/docs/refund-persistence.md
+++ b/docs/refund-persistence.md
@@ -1,0 +1,53 @@
+# Refund persistence and balance reservations
+
+PayBridge records every provider refund attempt. A refund is inserted as
+`Pending` before the provider call so concurrent requests reserve refundable
+balance atomically. Provider responses update the same record to `Pending`,
+`Refunded`, or `Failed`.
+
+Only `Pending` and `Refunded` records consume refundable balance. Failed attempts
+remain available for audit but do not prevent a replacement refund. A payment is
+marked `Refunded` only when cumulative provider-confirmed refunds reach the
+captured payment amount; an asynchronous pending response does not update the
+payment state prematurely.
+
+The audit record stores identifiers, amount, currency, reason, status, gateway,
+timestamps, and the normalized `RefundResponse`. It does not store credentials,
+authorization headers, or raw request payloads.
+
+## Migration
+
+Apply `AddRefundReservationIndex` with:
+
+```bash
+dotnet ef database update --project PayBridge.SDK/PayBridge.SDK.csproj
+```
+
+The migration adds an index over
+`Refunds(PaymentTransactionReference, Status)`. SQL Server requires the indexed
+reference to be bounded, so the column changes from `nvarchar(max)` to
+`nvarchar(450)`.
+
+Before applying it to an existing SQL Server database, confirm no stored value
+exceeds that limit:
+
+```sql
+SELECT Id, LEN(PaymentTransactionReference) AS ReferenceLength
+FROM Refunds
+WHERE LEN(PaymentTransactionReference) > 450;
+```
+
+Resolve any returned rows before deployment. Back up the database using the
+normal operational procedure before applying a production migration.
+
+## Rollback
+
+To roll back only this migration, target the previous migration:
+
+```bash
+dotnet ef database update 20250525015225_SetupDB \
+  --project PayBridge.SDK/PayBridge.SDK.csproj
+```
+
+The down migration removes the composite index and restores
+`PaymentTransactionReference` to `nvarchar(max)`. Refund audit rows are retained.


### PR DESCRIPTION
## Summary

- implement and register `IRefundRepository`
- atomically reserve refundable balance by inserting a pending audit record inside a serializable transaction
- count pending and confirmed refunds against the captured amount while excluding failed attempts
- update audit records with normalized provider references, statuses, timestamps, and responses
- mark the payment refunded only after cumulative provider-confirmed refunds reach the captured amount
- add the composite reservation index migration and deployment/rollback guidance

## Root cause

`PaymentService.RefundPaymentAsync` compared only the current request with the original transaction amount and never persisted `RefundTransaction`. Multiple partial refunds could therefore independently pass validation and cumulatively exceed the captured payment.

## TDD

Repository and service tests were written first and observed failing before implementation. Coverage includes:

- cumulative pending and confirmed balance enforcement
- failed attempts releasing refundable balance while remaining auditable
- eight concurrent 60-unit reservations against a 100-unit payment
- confirmed full-refund payment-state update
- pending asynchronous refund behavior
- rejected provider response auditing
- thrown provider failure auditing
- exhausted-balance rejection before the provider call
- DI registration and model-index metadata

## Concurrency and data model

The repository uses an in-process reservation lock plus a database `Serializable` transaction. The lock makes same-process behavior deterministic; serializable isolation and the `(PaymentTransactionReference, Status)` index protect the invariant across service instances.

Audit rows contain normalized refund fields and `RefundResponse`, not credentials, authorization headers, or raw request payloads.

## Migration

`AddRefundReservationIndex` bounds `PaymentTransactionReference` to `nvarchar(450)` for SQL Server indexing and creates `IX_Refunds_PaymentTransactionReference_Status`.

Before production deployment, run the documented query in `docs/refund-persistence.md` and resolve references longer than 450 characters. The down migration removes the index, restores `nvarchar(max)`, and retains refund rows.

## Validation

- refund-focused tests: 14 passed
- concurrency suite: passed five consecutive runs
- generated SQL inspected for expected ALTER COLUMN and CREATE INDEX only
- .NET 8 Release build: 0 warnings, 0 errors
- full test suite: 128 passed, 3 skipped sandbox tests, 0 failed
- vulnerable NuGet audit: none found
- changed-file formatting and `git diff --check`: clean

Closes #62


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced persistent refund handling with pending/successful/failed outcomes.
  * Added refundable balance reservation with atomic over-refund protection (including concurrent requests).
  * Payment transactions are updated to refunded only once confirmed refunded totals meet the captured amount.
  * Added refund repository support and automatic registration in the service container.
* **Documentation**
  * Documented refund persistence behavior, reservation rules, and migration/rollback notes.
* **Tests**
  * Added unit tests covering refund outcomes, reservation failure behavior, and concurrent reservation limits.
  * Added repository and DI registration tests, plus coverage for invalid reservation amounts.
* **Bug Fixes**
  * Fixed refund processing so gateway exceptions and rejections are recorded correctly and surfaced to callers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->