### PR TITLE
Fix ambiguous webhook provider detection

### DIFF
--- a/PayBridge.SDK.Test/Unit/GatewayExtractorTests.cs
+++ b/PayBridge.SDK.Test/Unit/GatewayExtractorTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using PayBridge.SDK.Enums;
 using PayBridge.SDK.Helper;
 using System.Dynamic;
+using System.Text.Json;
 using Xunit;
 
 namespace PayBridge.SDK.Test.Unit;
@@ -44,13 +45,12 @@ public class GatewayExtractorTests
     }
 
     [Fact]
-    public void DetectGatewayFromWebhook_ReturnsStripe_WhenTypeStartsWithStripeDot()
+    public void DetectGatewayFromWebhook_ReturnsStripe_ForEventEnvelope()
     {
-        // The implementation accesses data.type dynamically after casting to IDictionary.
-        // ExpandoObject satisfies both the IDictionary cast and dynamic property access.
         dynamic payload = new ExpandoObject();
-        payload.type = "stripe.payment_intent.succeeded";
+        payload.type = "payment_intent.succeeded";
         payload.id   = "evt_123";
+        payload.data = new { @object = new { id = "pi_123" } };
 
         PaymentGatewayType result = GatewayExtractor.DetectGatewayFromWebhook(payload);
 
@@ -129,19 +129,94 @@ public class GatewayExtractorTests
         result.Should().Be(PaymentGatewayType.Automatic);
     }
 
-    // Paystack takes priority over Stripe (event key checked before type key)
     [Fact]
-    public void DetectGatewayFromWebhook_PrioritisesEventKey_OverTypeKey()
+    public void DetectGatewayFromWebhook_ReturnsPaystack_ForEventAndDataEnvelope()
     {
         var payload = new Dictionary<string, object>
         {
             ["event"] = "charge.success",
-            ["type"]  = "stripe.some_event"
+            ["type"]  = "stripe.some_event",
+            ["data"] = new { reference = "PAY-1" }
         };
 
         var result = GatewayExtractor.DetectGatewayFromWebhook(payload);
 
         result.Should().Be(PaymentGatewayType.Paystack);
+    }
+
+    [Fact]
+    public void DetectGatewayFromWebhook_ReturnsFlutterwave_ForV3PayloadContainingEvent()
+    {
+        using var document = JsonDocument.Parse("""
+            {
+              "event": "charge.completed",
+              "data": {
+                "tx_ref": "merchant-ref",
+                "flw_ref": "FLW-MOCK-123"
+              }
+            }
+            """);
+
+        var result = GatewayExtractor.DetectGatewayFromWebhookResult(document.RootElement);
+
+        result.Status.Should().Be(WebhookGatewayDetectionStatus.Detected);
+        result.Gateway.Should().Be(PaymentGatewayType.Flutterwave);
+    }
+
+    [Fact]
+    public void DetectGatewayFromWebhook_ReturnsFlutterwave_ForCurrentWebhookEnvelope()
+    {
+        using var document = JsonDocument.Parse("""
+            {
+              "id": "wbk_W5p6ktwU0jQ8RO4By860",
+              "timestamp": 1735116884019,
+              "type": "charge.completed",
+              "data": { "reference": "merchant-ref", "status": "succeeded" }
+            }
+            """);
+
+        var result = GatewayExtractor.DetectGatewayFromWebhookResult(document.RootElement);
+
+        result.Status.Should().Be(WebhookGatewayDetectionStatus.Detected);
+        result.Gateway.Should().Be(PaymentGatewayType.Flutterwave);
+    }
+
+    [Fact]
+    public void DetectGatewayFromWebhook_ReportsAmbiguousPayload()
+    {
+        var payload = new Dictionary<string, object>
+        {
+            ["event"] = "charge.success",
+            ["data"] = new { reference = "PAY-1" },
+            ["_links"] = new { self = new { href = "https://api.checkout.com/events/evt_1" } }
+        };
+
+        var result = GatewayExtractor.DetectGatewayFromWebhookResult(payload);
+
+        result.Status.Should().Be(WebhookGatewayDetectionStatus.Ambiguous);
+        result.Gateway.Should().BeNull();
+    }
+
+    [Fact]
+    public void DetectGatewayFromWebhook_ReportsInvalidMalformedJson()
+    {
+        using var document = JsonDocument.Parse("[]");
+
+        var result = GatewayExtractor.DetectGatewayFromWebhookResult(document.RootElement);
+
+        result.Status.Should().Be(WebhookGatewayDetectionStatus.Invalid);
+        result.Gateway.Should().BeNull();
+    }
+
+    [Fact]
+    public void DetectGatewayFromWebhook_SupportsTypedPayloads()
+    {
+        var payload = new { @event = "charge.success", data = new { reference = "PAY-1" } };
+
+        var result = GatewayExtractor.DetectGatewayFromWebhookResult(payload);
+
+        result.Status.Should().Be(WebhookGatewayDetectionStatus.Detected);
+        result.Gateway.Should().Be(PaymentGatewayType.Paystack);
     }
 
     // ── ExtractReferenceFromWebhook ───────────────────────────────────────────

--- a/PayBridge.SDK/Helper/GatewayExtractor.cs
+++ b/PayBridge.SDK/Helper/GatewayExtractor.cs
@@ -13,54 +13,83 @@ public static class GatewayExtractor
     /// </summary>
     public static PaymentGatewayType DetectGatewayFromWebhook(object webhookData)
     {
-        // Convert to dynamic to inspect properties
-        dynamic data = webhookData;
+        var result = DetectGatewayFromWebhookResult(webhookData);
+        return result.Status == WebhookGatewayDetectionStatus.Detected
+            ? result.Gateway!.Value
+            : PaymentGatewayType.Automatic;
+    }
+
+    /// <summary>
+    /// Detects a provider from an unauthenticated payload shape. Prefer the
+    /// authenticated provider supplied by the webhook route whenever available.
+    /// </summary>
+    public static WebhookGatewayDetectionResult DetectGatewayFromWebhookResult(
+        object? webhookData)
+    {
+        if (webhookData is null)
+        {
+            return WebhookGatewayDetectionResult.Invalid;
+        }
 
         try
         {
-            var webhookDictionary = (IDictionary<string, object>)data;
-
-            // Paystack webhooks contain an 'event' property
-            if (webhookDictionary.ContainsKey("event"))
+            var payload = webhookData is JsonElement element
+                ? element
+                : JsonSerializer.SerializeToElement(webhookData);
+            if (payload.ValueKind != JsonValueKind.Object)
             {
-                return PaymentGatewayType.Paystack;
+                return WebhookGatewayDetectionResult.Invalid;
             }
 
-            // Flutterwave webhooks contain a 'flw_ref' property
-            if (webhookDictionary.ContainsKey("flw_ref"))
+            var candidates = new HashSet<PaymentGatewayType>();
+            var data = GetObject(payload, "data");
+
+            if (HasString(payload, "flw_ref") ||
+                (data is { } flutterwaveData && HasString(flutterwaveData, "flw_ref")) ||
+                (StartsWith(payload, "id", "wbk_") && HasProperty(payload, "timestamp")))
             {
-                return PaymentGatewayType.Flutterwave;
+                candidates.Add(PaymentGatewayType.Flutterwave);
             }
 
-            // Stripe webhooks contain a 'type' property starting with 'stripe.'
-            if (webhookDictionary.ContainsKey("type") &&
-                data.type.ToString().StartsWith("stripe."))
+            if (!candidates.Contains(PaymentGatewayType.Flutterwave) &&
+                HasString(payload, "event") && data is not null)
             {
-                return PaymentGatewayType.Stripe;
+                candidates.Add(PaymentGatewayType.Paystack);
             }
 
-            // Checkout.com webhooks contain a '_links' property
-            if (webhookDictionary.ContainsKey("_links"))
+            if (StartsWith(payload, "id", "evt_") &&
+                HasString(payload, "type") &&
+                data is { } stripeData &&
+                stripeData.TryGetProperty("object", out _))
             {
-                return PaymentGatewayType.Checkout;
+                candidates.Add(PaymentGatewayType.Stripe);
             }
 
-            if (webhookDictionary.ContainsKey("reference"))
+            if (payload.TryGetProperty("_links", out var links) &&
+                links.ValueKind == JsonValueKind.Object)
             {
-                var reference = webhookDictionary["reference"]?.ToString();
-                if (reference?.StartsWith(GatewayReferencePrefixes.Korapay, StringComparison.OrdinalIgnoreCase) == true)
-                {
-                    return PaymentGatewayType.Korapay;
-                }
+                candidates.Add(PaymentGatewayType.Checkout);
             }
 
-            // Default to Automatic if we can't determine the gateway
-            return PaymentGatewayType.Automatic;
+            var reference = GetString(payload, "reference") ??
+                (data is { } providerData ? GetString(providerData, "reference") : null);
+            if (reference?.StartsWith(
+                    GatewayReferencePrefixes.Korapay,
+                    StringComparison.OrdinalIgnoreCase) == true)
+            {
+                candidates.Add(PaymentGatewayType.Korapay);
+            }
+
+            return candidates.Count switch
+            {
+                0 => WebhookGatewayDetectionResult.Unknown,
+                1 => WebhookGatewayDetectionResult.Detected(candidates.Single()),
+                _ => WebhookGatewayDetectionResult.Ambiguous
+            };
         }
-        catch
+        catch (Exception)
         {
-            // If we encounter any errors, default to Automatic
-            return PaymentGatewayType.Automatic;
+            return WebhookGatewayDetectionResult.Invalid;
         }
     }
 
@@ -206,4 +235,46 @@ public static class GatewayExtractor
             : element.ToString();
     }
 
+    private static JsonElement? GetObject(JsonElement element, string name) =>
+        element.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.Object
+            ? value
+            : null;
+
+    private static bool HasString(JsonElement element, string name) =>
+        element.TryGetProperty(name, out var value) &&
+        value.ValueKind == JsonValueKind.String &&
+        !string.IsNullOrWhiteSpace(value.GetString());
+
+    private static bool HasProperty(JsonElement element, string name) =>
+        element.TryGetProperty(name, out var value) &&
+        value.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined;
+
+    private static bool StartsWith(JsonElement element, string name, string prefix) =>
+        element.TryGetProperty(name, out var value) &&
+        value.ValueKind == JsonValueKind.String &&
+        value.GetString()?.StartsWith(prefix, StringComparison.Ordinal) == true;
+
+}
+
+public enum WebhookGatewayDetectionStatus
+{
+    Detected,
+    Unknown,
+    Ambiguous,
+    Invalid
+}
+
+public sealed record WebhookGatewayDetectionResult(
+    WebhookGatewayDetectionStatus Status,
+    PaymentGatewayType? Gateway)
+{
+    public static WebhookGatewayDetectionResult Unknown { get; } =
+        new(WebhookGatewayDetectionStatus.Unknown, null);
+    public static WebhookGatewayDetectionResult Ambiguous { get; } =
+        new(WebhookGatewayDetectionStatus.Ambiguous, null);
+    public static WebhookGatewayDetectionResult Invalid { get; } =
+        new(WebhookGatewayDetectionStatus.Invalid, null);
+
+    public static WebhookGatewayDetectionResult Detected(PaymentGatewayType gateway) =>
+        new(WebhookGatewayDetectionStatus.Detected, gateway);
 }


### PR DESCRIPTION
## Summary
- replace dynamic key-order detection with explicit provider envelope rules
- identify Flutterwave v3 payloads containing both `event` and `data.flw_ref` correctly
- support current Flutterwave, Paystack, Stripe, Checkout.com, and Korapay shapes across JsonElement, dictionaries, and typed objects
- expose structured detected, unknown, ambiguous, and invalid outcomes while preserving the compatibility API

## Root cause
The legacy detector treated any payload with an `event` property as Paystack before inspecting Flutterwave-specific fields. Flutterwave v3 webhooks also contain `event`, so valid Flutterwave notifications followed the wrong reference-extraction path.

Authenticated route/provider context remains the trusted source; payload detection is explicitly documented as a fallback and does not replace signature verification.

## Validation
- 135 tests passed
- 3 opt-in sandbox tests skipped
- Release build succeeded with 0 warnings and 0 errors

Closes #63