### PR TITLE
Add durable payment creation idempotency

### DIFF
--- a/PayBridge.SDK.Test/Unit/PaymentIdempotencyPersistenceTests.cs
+++ b/PayBridge.SDK.Test/Unit/PaymentIdempotencyPersistenceTests.cs
@@ -1,0 +1,61 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using PayBridge.SDK.Entities;
+using PayBridge.SDK.Enums;
+using Xunit;
+
+namespace PayBridge.SDK.Test.Unit;
+
+[Trait("Category", "Unit")]
+public class PaymentIdempotencyPersistenceTests
+{
+    [Fact]
+    public async Task Database_rejects_duplicate_payment_idempotency_keys()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        var options = new DbContextOptionsBuilder<PayBridgeDbContext>()
+            .UseSqlite(connection)
+            .Options;
+        await using var context = new PayBridgeDbContext(options);
+        await context.Database.EnsureCreatedAsync();
+        context.Transactions.Add(NewTransaction("first", "checkout-123"));
+        await context.SaveChangesAsync();
+        context.Transactions.Add(NewTransaction("second", "checkout-123"));
+
+        var action = () => context.SaveChangesAsync();
+
+        await action.Should().ThrowAsync<DbUpdateException>();
+    }
+
+    [Fact]
+    public void Model_defines_bounded_unique_idempotency_key()
+    {
+        var options = new DbContextOptionsBuilder<PayBridgeDbContext>()
+            .UseSqlite("Data Source=:memory:")
+            .Options;
+        using var context = new PayBridgeDbContext(options);
+        var entity = context.Model.FindEntityType(typeof(PaymentTransaction))!;
+        var property = entity.FindProperty(nameof(PaymentTransaction.IdempotencyKey))!;
+        var index = entity.GetIndexes().Single(item =>
+            item.Properties.Count == 1 && item.Properties[0] == property);
+
+        property.GetMaxLength().Should().Be(255);
+        index.IsUnique.Should().BeTrue();
+    }
+
+    private static PaymentTransaction NewTransaction(string id, string key) => new()
+    {
+        Id = id,
+        IdempotencyKey = key,
+        RequestFingerprint = new string('A', 64),
+        TransactionReference = $"PAY-{id}",
+        Amount = 100m,
+        Currency = "NGN",
+        CustomerEmail = "customer@example.test",
+        Status = PaymentStatus.Pending,
+        Gateway = PaymentGatewayType.Paystack,
+        CreatedAt = DateTime.UtcNow
+    };
+}

--- a/PayBridge.SDK.Test/Unit/PaymentServiceIdempotencyTests.cs
+++ b/PayBridge.SDK.Test/Unit/PaymentServiceIdempotencyTests.cs
@@ -1,0 +1,97 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using PayBridge.SDK.Application.Dtos;
+using PayBridge.SDK.Dtos.Request;
+using PayBridge.SDK.Dtos.Response;
+using PayBridge.SDK.Entities;
+using PayBridge.SDK.Enums;
+using PayBridge.SDK.Interfaces;
+using Xunit;
+
+namespace PayBridge.SDK.Test.Unit;
+
+[Trait("Category", "Unit")]
+public class PaymentServiceIdempotencyTests
+{
+    [Fact]
+    public async Task Concurrent_requests_with_same_key_call_gateway_once_and_replay_result()
+    {
+        var fixture = CreateFixture();
+        var request = NewRequest("checkout-123");
+
+        var results = await Task.WhenAll(
+            fixture.Service.CreatePaymentAsync(request, PaymentGatewayType.Paystack),
+            fixture.Service.CreatePaymentAsync(request, PaymentGatewayType.Paystack));
+
+        results.Should().OnlyContain(result => result.TransactionReference == "PAY-123");
+        fixture.Gateway.Verify(gateway =>
+            gateway.CreatePaymentAsync(It.IsAny<PaymentRequest>()), Times.Once);
+        fixture.Transactions.Verify(repository =>
+            repository.CreateAsync(It.IsAny<PaymentTransaction>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Reusing_key_with_different_parameters_is_rejected_without_provider_call()
+    {
+        var fixture = CreateFixture();
+        await fixture.Service.CreatePaymentAsync(
+            NewRequest("checkout-123"), PaymentGatewayType.Paystack);
+        var changed = NewRequest("checkout-123");
+        changed.Amount = 200m;
+
+        var action = () => fixture.Service.CreatePaymentAsync(
+            changed, PaymentGatewayType.Paystack);
+
+        await action.Should().ThrowAsync<Exception>()
+            .WithMessage("*different payment parameters*");
+        fixture.Gateway.Verify(gateway =>
+            gateway.CreatePaymentAsync(It.IsAny<PaymentRequest>()), Times.Once);
+    }
+
+    private static Fixture CreateFixture()
+    {
+        PaymentTransaction? stored = null;
+        var transactions = new Mock<ITransactionRepository>();
+        transactions.Setup(repository => repository.GetByIdempotencyKeyAsync("checkout-123"))
+            .ReturnsAsync(() => stored);
+        transactions.Setup(repository => repository.CreateAsync(It.IsAny<PaymentTransaction>()))
+            .Callback<PaymentTransaction>(transaction => stored = transaction)
+            .ReturnsAsync((PaymentTransaction transaction) => transaction);
+        transactions.Setup(repository => repository.UpdateAsync(It.IsAny<PaymentTransaction>()))
+            .ReturnsAsync((PaymentTransaction transaction) => transaction);
+
+        var gateway = new Mock<IPaymentGateway>();
+        gateway.SetupGet(item => item.GatewayType).Returns(PaymentGatewayType.Paystack);
+        gateway.Setup(item => item.CreatePaymentAsync(It.IsAny<PaymentRequest>()))
+            .ReturnsAsync(new PaymentResponse
+            {
+                Success = true,
+                TransactionReference = "PAY-123",
+                CheckoutUrl = "https://checkout.example/PAY-123",
+                Status = PaymentStatus.Pending
+            });
+
+        var service = new PaymentService(
+            transactions.Object,
+            Mock.Of<IRefundRepository>(),
+            [gateway.Object],
+            NullLogger<PaymentService>.Instance,
+            new PaymentGatewayConfig());
+        return new Fixture(service, transactions, gateway);
+    }
+
+    private static PaymentRequest NewRequest(string key) => new()
+    {
+        IdempotencyKey = key,
+        Amount = 100m,
+        Currency = "NGN",
+        CustomerEmail = "customer@example.test",
+        CustomerName = "Customer"
+    };
+
+    private sealed record Fixture(
+        PaymentService Service,
+        Mock<ITransactionRepository> Transactions,
+        Mock<IPaymentGateway> Gateway);
+}

--- a/PayBridge.SDK/Dtos/Request/PaymentRequest.cs
+++ b/PayBridge.SDK/Dtos/Request/PaymentRequest.cs
@@ -3,6 +3,7 @@
 namespace PayBridge.SDK.Dtos.Request;
 public class PaymentRequest
 {
+    public string? IdempotencyKey { get; set; }
     public string? Logo { get; set; }
 
     public decimal Amount { get; set; }

--- a/PayBridge.SDK/Entities/PaymentTransaction.cs
+++ b/PayBridge.SDK/Entities/PaymentTransaction.cs
@@ -4,6 +4,8 @@ namespace PayBridge.SDK.Entities;
 public class PaymentTransaction
 {
     public string Id { get; set; } = string.Empty;
+    public string? IdempotencyKey { get; set; }
+    public string RequestFingerprint { get; set; } = string.Empty;
     public string TransactionReference { get; set; } = string.Empty;
     public decimal Amount { get; set; }
     public string Currency { get; set; } = string.Empty;

--- a/PayBridge.SDK/Interfaces/ITransactionRepository.cs
+++ b/PayBridge.SDK/Interfaces/ITransactionRepository.cs
@@ -18,6 +18,8 @@ public interface ITransactionRepository
     /// <returns></returns>
     Task<PaymentTransaction?> GetByReferenceAsync(string reference);
 
+    Task<PaymentTransaction?> GetByIdempotencyKeyAsync(string idempotencyKey);
+
     /// <summary>
     /// updates an existing payment transaction
     /// </summary>

--- a/PayBridge.SDK/Migrations/20260718083842_AddPaymentIdempotency.Designer.cs
+++ b/PayBridge.SDK/Migrations/20260718083842_AddPaymentIdempotency.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using PayBridge.SDK;
 
@@ -11,9 +12,11 @@ using PayBridge.SDK;
 namespace PayBridge.SDK.Migrations
 {
     [DbContext(typeof(PayBridgeDbContext))]
-    partial class PayBridgeDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260718083842_AddPaymentIdempotency")]
+    partial class AddPaymentIdempotency
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/PayBridge.SDK/Migrations/20260718083842_AddPaymentIdempotency.cs
+++ b/PayBridge.SDK/Migrations/20260718083842_AddPaymentIdempotency.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PayBridge.SDK.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPaymentIdempotency : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            var (keyType, fingerprintType) = GetProviderColumnTypes();
+            migrationBuilder.AddColumn<string>(
+                name: "IdempotencyKey",
+                table: "Transactions",
+                type: keyType,
+                maxLength: 255,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "RequestFingerprint",
+                table: "Transactions",
+                type: fingerprintType,
+                maxLength: 64,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Transactions_IdempotencyKey",
+                table: "Transactions",
+                column: "IdempotencyKey",
+                unique: true,
+                filter: ActiveProvider.Contains("SqlServer")
+                    ? "[IdempotencyKey] IS NOT NULL"
+                    : null);
+        }
+
+        private (string Key, string Fingerprint) GetProviderColumnTypes()
+        {
+            if (ActiveProvider.Contains("Npgsql"))
+            {
+                return ("character varying(255)", "character varying(64)");
+            }
+
+            if (ActiveProvider.Contains("MySql"))
+            {
+                return ("varchar(255)", "varchar(64)");
+            }
+
+            if (ActiveProvider.Contains("Sqlite"))
+            {
+                return ("TEXT", "TEXT");
+            }
+
+            return ("nvarchar(255)", "nvarchar(64)");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Transactions_IdempotencyKey",
+                table: "Transactions");
+
+            migrationBuilder.DropColumn(
+                name: "IdempotencyKey",
+                table: "Transactions");
+
+            migrationBuilder.DropColumn(
+                name: "RequestFingerprint",
+                table: "Transactions");
+        }
+    }
+}

--- a/PayBridge.SDK/Persistence/PayBridgeDbContext.cs
+++ b/PayBridge.SDK/Persistence/PayBridgeDbContext.cs
@@ -13,6 +13,16 @@ public class PayBridgeDbContext : DbContext
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
+        modelBuilder.Entity<PaymentTransaction>()
+            .HasIndex(transaction => transaction.IdempotencyKey)
+            .IsUnique();
+        modelBuilder.Entity<PaymentTransaction>()
+            .Property(transaction => transaction.IdempotencyKey)
+            .HasMaxLength(255);
+        modelBuilder.Entity<PaymentTransaction>()
+            .Property(transaction => transaction.RequestFingerprint)
+            .HasMaxLength(64);
+
         modelBuilder.Entity<RefundTransaction>()
             .HasIndex(refund => new { refund.PaymentTransactionReference, refund.Status });
     }

--- a/PayBridge.SDK/Repositories/TransactionRepository.cs
+++ b/PayBridge.SDK/Repositories/TransactionRepository.cs
@@ -52,6 +52,13 @@ public class TransactionRepository(PayBridgeDbContext dbContext, ILogger<Transac
             .FirstOrDefaultAsync(t => t.TransactionReference == reference);
     }
 
+    public async Task<PaymentTransaction?> GetByIdempotencyKeyAsync(string idempotencyKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(idempotencyKey);
+        return await _dbContext.Transactions
+            .FirstOrDefaultAsync(transaction => transaction.IdempotencyKey == idempotencyKey);
+    }
+
     /// <inheritdoc/>
     public async Task<IEnumerable<PaymentTransaction>> GetByCustomerEmailAsync(string email)
     {

--- a/PayBridge.SDK/Services/PaymentService.cs
+++ b/PayBridge.SDK/Services/PaymentService.cs
@@ -196,7 +196,7 @@ public class PaymentService : IPaymentService
             request.SavedPaymentMethodId,
             request.AppName,
             request.Logo,
-            Metadata = request.Metadata.OrderBy(item => item.Key).ToArray(),
+            Metadata = request.Metadata.OrderBy(item => item.Key, StringComparer.Ordinal).ToArray(),
             Gateway = gateway
         });
         return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value)));

--- a/PayBridge.SDK/Services/PaymentService.cs
+++ b/PayBridge.SDK/Services/PaymentService.cs
@@ -9,11 +9,16 @@ using PayBridge.SDK.Enums;
 using PayBridge.SDK.Exceptions;
 using PayBridge.SDK.Interfaces;
 using System.Text.Json;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
 
 namespace PayBridge.SDK;
 
 public class PaymentService : IPaymentService
 {
+    private static readonly object IdempotencyLocksGate = new();
+    private static readonly Dictionary<string, IdempotencyLock> IdempotencyLocks = [];
     private readonly ITransactionRepository _transactionRepository;
     private readonly IRefundRepository _refundRepository;
     private readonly Dictionary<PaymentGatewayType, IPaymentGateway> _gateways;
@@ -60,6 +65,11 @@ public class PaymentService : IPaymentService
             throw new PaymentGatewayException($"Gateway {selectedGateway} is not configured");
         }
 
+        if (!string.IsNullOrWhiteSpace(request.IdempotencyKey))
+        {
+            return await CreateIdempotentPaymentAsync(request, selectedGateway);
+        }
+
         try
         {
             var response = await _gateways[selectedGateway].CreatePaymentAsync(request);
@@ -91,6 +101,160 @@ public class PaymentService : IPaymentService
             _logger.LogError(ex, "Payment processing failed with {Gateway}", selectedGateway);
             throw new PaymentGatewayException($"Payment processing failed with {selectedGateway}", ex);
         }
+    }
+
+    private async Task<PaymentResponse> CreateIdempotentPaymentAsync(
+        PaymentRequest request,
+        PaymentGatewayType selectedGateway)
+    {
+        if (request.IdempotencyKey!.Length > 255)
+        {
+            throw new ArgumentException("Idempotency key cannot exceed 255 characters.", nameof(request));
+        }
+
+        var key = request.IdempotencyKey;
+        var fingerprint = CreateFingerprint(request, selectedGateway);
+        var idempotencyLock = AcquireIdempotencyLock(key);
+        await idempotencyLock.Semaphore.WaitAsync();
+        try
+        {
+            var existing = await _transactionRepository.GetByIdempotencyKeyAsync(key);
+            if (existing is not null)
+            {
+                return ReplayIdempotentPayment(existing, fingerprint);
+            }
+
+            PaymentTransaction transaction;
+            try
+            {
+                transaction = await _transactionRepository.CreateAsync(new PaymentTransaction
+                {
+                    IdempotencyKey = key,
+                    RequestFingerprint = fingerprint,
+                    TransactionReference = $"IDEMPOTENCY-{Guid.NewGuid():N}",
+                    Amount = request.Amount,
+                    Currency = request.Currency,
+                    CustomerEmail = request.CustomerEmail,
+                    CustomerName = request.CustomerName,
+                    Status = PaymentStatus.Pending,
+                    Gateway = selectedGateway,
+                    CreatedAt = DateTime.UtcNow
+                });
+            }
+            catch (DbUpdateException)
+            {
+                existing = await _transactionRepository.GetByIdempotencyKeyAsync(key);
+                if (existing is null)
+                {
+                    throw;
+                }
+
+                return ReplayIdempotentPayment(existing, fingerprint);
+            }
+
+            try
+            {
+                var response = await _gateways[selectedGateway].CreatePaymentAsync(request);
+                transaction.TransactionReference = string.IsNullOrWhiteSpace(response.TransactionReference)
+                    ? transaction.TransactionReference
+                    : response.TransactionReference;
+                transaction.Status = response.Success ? response.Status : PaymentStatus.Failed;
+                transaction.GatewayResponse = JsonSerializer.Serialize(response);
+                await _transactionRepository.UpdateAsync(transaction);
+                return response;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "Idempotent payment outcome is uncertain for {Gateway}", selectedGateway);
+                throw new PaymentGatewayException(
+                    $"Payment processing failed with {selectedGateway}; retry with the same idempotency key.", ex);
+            }
+        }
+        finally
+        {
+            idempotencyLock.Semaphore.Release();
+            ReleaseIdempotencyLock(key, idempotencyLock);
+        }
+    }
+
+    private static string CreateFingerprint(
+        PaymentRequest request,
+        PaymentGatewayType gateway)
+    {
+        var value = JsonSerializer.Serialize(new
+        {
+            request.Amount,
+            Currency = request.Currency.ToUpperInvariant(),
+            Email = request.CustomerEmail.Trim().ToUpperInvariant(),
+            request.CustomerName,
+            request.Description,
+            request.RedirectUrl,
+            request.WebhookUrl,
+            request.PaymentMethodType,
+            request.CustomerPhone,
+            request.SavedPaymentMethodId,
+            request.AppName,
+            request.Logo,
+            Metadata = request.Metadata.OrderBy(item => item.Key).ToArray(),
+            Gateway = gateway
+        });
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value)));
+    }
+
+    private static PaymentResponse ReplayIdempotentPayment(
+        PaymentTransaction existing,
+        string fingerprint)
+    {
+        if (!CryptographicOperations.FixedTimeEquals(
+                Encoding.UTF8.GetBytes(existing.RequestFingerprint),
+                Encoding.UTF8.GetBytes(fingerprint)))
+        {
+            throw new PaymentGatewayException(
+                "The idempotency key was already used with different payment parameters.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(existing.GatewayResponse))
+        {
+            return JsonSerializer.Deserialize<PaymentResponse>(existing.GatewayResponse)
+                ?? throw new PaymentGatewayException("The stored idempotent response is invalid.");
+        }
+
+        throw new PaymentGatewayException("The idempotent payment request is still processing.");
+    }
+
+    private static IdempotencyLock AcquireIdempotencyLock(string key)
+    {
+        lock (IdempotencyLocksGate)
+        {
+            if (!IdempotencyLocks.TryGetValue(key, out var value))
+            {
+                value = new IdempotencyLock();
+                IdempotencyLocks.Add(key, value);
+            }
+
+            value.Users++;
+            return value;
+        }
+    }
+
+    private static void ReleaseIdempotencyLock(string key, IdempotencyLock value)
+    {
+        lock (IdempotencyLocksGate)
+        {
+            value.Users--;
+            if (value.Users == 0)
+            {
+                IdempotencyLocks.Remove(key);
+                value.Semaphore.Dispose();
+            }
+        }
+    }
+
+    private sealed class IdempotencyLock
+    {
+        public SemaphoreSlim Semaphore { get; } = new(1, 1);
+        public int Users { get; set; }
     }
 
     /// <inheritdoc/>

--- a/docs/payment-idempotency.md
+++ b/docs/payment-idempotency.md
@@ -1,0 +1,23 @@
+# Payment creation idempotency
+
+Set `PaymentRequest.IdempotencyKey` to a stable, client-generated value for each
+logical checkout attempt. UUID v4 values are recommended. Keys may contain up to
+255 characters.
+
+PayBridge reserves the key before calling a gateway and stores the normalized
+`PaymentResponse`. Repeating the same key and payment parameters returns that
+stored response without another gateway call. Reusing a key with different
+amount, currency, customer, redirect, webhook, payment method, or gateway data
+is rejected.
+
+If a gateway call fails without a definitive response, the reservation remains
+pending because the provider outcome may be uncertain. Retry using the same key;
+do not generate a new key for a network timeout. Pending attempts require
+provider reconciliation before a new provider request is safe.
+
+Requests without an idempotency key retain the legacy behavior and are not safe
+to retry automatically.
+
+Provider-native behavior differs. Stripe supports an `Idempotency-Key` header;
+Paystack enforces unique transaction references. PayBridge's persisted key is
+the provider-neutral protection and does not replace provider reconciliation.


### PR DESCRIPTION
## Summary
- add an optional client-generated idempotency key to payment requests
- reserve keys durably before invoking a payment provider
- replay the complete stored response for matching retries without another provider call
- reject key reuse when payment-shaping parameters differ
- add a provider-portable unique index migration and operational guidance

## Why
Double-clicks, client retries, and concurrent application instances can otherwise initialize the same logical payment more than once. Provider behavior differs: Stripe supports idempotency keys directly while Paystack relies on unique references, so PayBridge now provides a durable provider-neutral guard.

Uncertain provider outcomes remain pending and are not automatically reissued. Requests without a key retain legacy behavior.

## Validation
- focused idempotency suite: 4 passed
- full suite: 139 passed, 3 opt-in sandbox tests skipped
- Release build: 0 warnings, 0 errors
- transitive NuGet vulnerability audit: clean

Part of #64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added idempotent payment creation using client-supplied keys.
  * Repeated requests with the same key and payment details replay the original result without duplicate gateway charges.
  * Reusing a key with different payment details is rejected.
  * Added support for persisting and retrieving idempotency keys.

* **Documentation**
  * Added guidance on key usage, retries, and provider-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->