### PR TITLE
Add webhook replay protection to the example flow

### DIFF
--- a/PayBridge.SDK.Example/Controllers/WebhookController.cs
+++ b/PayBridge.SDK.Example/Controllers/WebhookController.cs
@@ -43,17 +43,20 @@ public class WebhookController : ControllerBase
     private readonly IPaymentService _payment;
     private readonly IWebhookSignatureVerifier _webhookVerifier;
     private readonly OrderService _orders;
+    private readonly IWebhookReplayStore _replayStore;
     private readonly ILogger<WebhookController> _log;
 
     public WebhookController(
         IPaymentService paymentService,
         IWebhookSignatureVerifier webhookVerifier,
         OrderService orderService,
+        IWebhookReplayStore replayStore,
         ILogger<WebhookController> logger)
     {
         _payment = paymentService;
         _webhookVerifier = webhookVerifier;
         _orders = orderService;
+        _replayStore = replayStore;
         _log = logger;
     }
 
@@ -161,6 +164,12 @@ public class WebhookController : ControllerBase
             return BadRequest(new { received = true, processed = false, reason = "no_reference" });
         }
 
+        if (!_replayStore.TryStart(gateway, rawBody, out var receiptId))
+        {
+            _log.LogInformation("Ignored replayed {Gateway} webhook", gateway);
+            return Ok(new { received = true, processed = false, duplicate = true });
+        }
+
         _log.LogInformation(
             "Authenticated {Gateway} webhook for {Reference}",
             gateway,
@@ -170,66 +179,77 @@ public class WebhookController : ControllerBase
         //
         // NEVER trust the webhook body alone — always call VerifyPaymentAsync to
         // confirm the transaction status server-side before fulfilling the order.
-        var paymentVerification = await _payment.VerifyPaymentAsync(reference, gateway);
-
-        if (!paymentVerification.Success ||
-            paymentVerification.Status != PaymentStatus.Successful)
+        try
         {
-            _log.LogWarning(
-                "Webhook for {Reference} — verification failed or status={Status}",
-                reference,
-                paymentVerification.Status);
+            var paymentVerification = await _payment.VerifyPaymentAsync(reference, gateway);
+
+            if (!paymentVerification.Success ||
+                paymentVerification.Status != PaymentStatus.Successful)
+            {
+                _replayStore.Abandon(receiptId);
+                _log.LogWarning(
+                    "Webhook for {Reference} — verification failed or status={Status}",
+                    reference,
+                    paymentVerification.Status);
+
+                return Ok(new
+                {
+                    received = true,
+                    processed = false,
+                    status = paymentVerification.Status.ToString()
+                });
+            }
+
+            // ── Step 4: fulfil the order ──────────────────────────────────────────
+            //
+            // Look up the order using the orderId we embedded in Metadata, then mark
+            // it as paid. In a real app you'd:
+            //   • Send a confirmation email
+            //   • Provision the purchased product / subscription
+            //   • Emit a domain event for downstream services
+            var orderId = paymentVerification.Metadata.GetValueOrDefault("orderId")
+                       ?? _orders.GetByTransactionRef(reference)?.OrderId;
+            var order = orderId is null ? null : _orders.GetById(orderId);
+
+            if (order is not null &&
+                paymentVerification.TransactionReference.Equals(
+                    reference,
+                    StringComparison.Ordinal) &&
+                paymentVerification.Amount == order.Amount &&
+                paymentVerification.Currency.Equals(
+                    order.Currency,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                _orders.MarkAsPaid(order.OrderId, reference);
+                _replayStore.Complete(receiptId);
+                _log.LogInformation("Order {OrderId} marked as paid ✓", order.OrderId);
+            }
+            else
+            {
+                _replayStore.Abandon(receiptId);
+                _log.LogWarning(
+                    "Verified payment {Reference} did not match the original order",
+                    reference);
+                return Ok(new
+                {
+                    received = true,
+                    processed = false,
+                    status = "order_mismatch"
+                });
+            }
 
             return Ok(new
             {
                 received = true,
-                processed = false,
-                status = paymentVerification.Status.ToString()
-            });
-        }
-
-        // ── Step 4: fulfil the order ──────────────────────────────────────────
-        //
-        // Look up the order using the orderId we embedded in Metadata, then mark
-        // it as paid. In a real app you'd:
-        //   • Send a confirmation email
-        //   • Provision the purchased product / subscription
-        //   • Emit a domain event for downstream services
-        var orderId = paymentVerification.Metadata.GetValueOrDefault("orderId")
-                   ?? _orders.GetByTransactionRef(reference)?.OrderId;
-        var order = orderId is null ? null : _orders.GetById(orderId);
-
-        if (order is not null &&
-            paymentVerification.TransactionReference.Equals(
+                processed = true,
                 reference,
-                StringComparison.Ordinal) &&
-            paymentVerification.Amount == order.Amount &&
-            paymentVerification.Currency.Equals(
-                order.Currency,
-                StringComparison.OrdinalIgnoreCase))
-        {
-            _orders.MarkAsPaid(order.OrderId, reference);
-            _log.LogInformation("Order {OrderId} marked as paid ✓", order.OrderId);
-        }
-        else
-        {
-            _log.LogWarning(
-                "Verified payment {Reference} did not match the original order",
-                reference);
-            return Ok(new
-            {
-                received = true,
-                processed = false,
-                status = "order_mismatch"
+                gateway = gateway.ToString()
             });
         }
-
-        return Ok(new
+        catch
         {
-            received = true,
-            processed = true,
-            reference,
-            gateway = gateway.ToString()
-        });
+            _replayStore.Abandon(receiptId);
+            throw;
+        }
     }
 }

--- a/PayBridge.SDK.Example/Program.cs
+++ b/PayBridge.SDK.Example/Program.cs
@@ -120,6 +120,8 @@ builder.Services.AddPayBridge(builder.Configuration, config =>
 // In a real app this would be your domain service / EF Core repository.
 
 builder.Services.AddSingleton<PayBridge.SDK.Example.Services.OrderService>();
+builder.Services.AddSingleton<PayBridge.SDK.Example.Services.IWebhookReplayStore,
+    PayBridge.SDK.Example.Services.WebhookReplayStore>();
 
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/PayBridge.SDK.Example/Services/OrderService.cs
+++ b/PayBridge.SDK.Example/Services/OrderService.cs
@@ -15,15 +15,15 @@ public class OrderService
     // ── Internal record ───────────────────────────────────────────────────────
 
     public record Order(
-        string  OrderId,
-        string  CustomerEmail,
+        string OrderId,
+        string CustomerEmail,
         decimal Amount,
-        string  Currency,
-        string  Description)
+        string Currency,
+        string Description)
     {
-        public PaymentStatus Status          { get; set; } = PaymentStatus.Pending;
-        public string        TransactionRef  { get; set; } = string.Empty;
-        public DateTime      PaidAt          { get; set; }
+        public PaymentStatus Status { get; set; } = PaymentStatus.Pending;
+        public string TransactionRef { get; set; } = string.Empty;
+        public DateTime PaidAt { get; set; }
     }
 
     // ── Storage ───────────────────────────────────────────────────────────────
@@ -38,17 +38,17 @@ public class OrderService
     /// in <c>Metadata</c> and tie the payment back to the order in your webhook.
     /// </summary>
     public Order Create(
-        string  customerEmail,
+        string customerEmail,
         decimal amount,
-        string  currency,
-        string  description)
+        string currency,
+        string description)
     {
         var order = new Order(
-            OrderId:       Guid.NewGuid().ToString("N")[..12].ToUpperInvariant(),
+            OrderId: Guid.NewGuid().ToString("N")[..12].ToUpperInvariant(),
             CustomerEmail: customerEmail,
-            Amount:        amount,
-            Currency:      currency,
-            Description:   description);
+            Amount: amount,
+            Currency: currency,
+            Description: description);
 
         _orders[order.OrderId] = order;
         return order;
@@ -69,11 +69,18 @@ public class OrderService
     public bool MarkAsPaid(string orderId, string transactionRef)
     {
         if (!_orders.TryGetValue(orderId, out var order)) return false;
+        lock (order)
+        {
+            if (order.Status == PaymentStatus.Successful)
+            {
+                return order.TransactionRef.Equals(transactionRef, StringComparison.Ordinal);
+            }
 
-        order.Status         = PaymentStatus.Successful;
-        order.TransactionRef = transactionRef;
-        order.PaidAt         = DateTime.UtcNow;
-        return true;
+            order.Status = PaymentStatus.Successful;
+            order.TransactionRef = transactionRef;
+            order.PaidAt = DateTime.UtcNow;
+            return true;
+        }
     }
 
     /// <summary>Marks an order as failed.</summary>

--- a/PayBridge.SDK.Example/Services/WebhookReplayStore.cs
+++ b/PayBridge.SDK.Example/Services/WebhookReplayStore.cs
@@ -1,0 +1,59 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using PayBridge.SDK.Enums;
+
+namespace PayBridge.SDK.Example.Services;
+
+public interface IWebhookReplayStore
+{
+    bool TryStart(PaymentGatewayType gateway, ReadOnlySpan<byte> payload, out string receiptId);
+    void Complete(string receiptId);
+    void Abandon(string receiptId);
+}
+
+public sealed class WebhookReplayStore : IWebhookReplayStore
+{
+    private static readonly TimeSpan Retention = TimeSpan.FromHours(24);
+    private const int MaximumReceipts = 10_000;
+    private readonly ConcurrentDictionary<string, DateTimeOffset> _receipts = new();
+
+    public bool TryStart(
+        PaymentGatewayType gateway,
+        ReadOnlySpan<byte> payload,
+        out string receiptId)
+    {
+        RemoveExpiredReceipts();
+        var gatewayBytes = BitConverter.GetBytes((int)gateway);
+        var input = new byte[gatewayBytes.Length + payload.Length];
+        gatewayBytes.CopyTo(input, 0);
+        payload.CopyTo(input.AsSpan(gatewayBytes.Length));
+        receiptId = Convert.ToHexString(SHA256.HashData(input));
+        return _receipts.TryAdd(receiptId, DateTimeOffset.UtcNow);
+    }
+
+    public void Complete(string receiptId) =>
+        _receipts[receiptId] = DateTimeOffset.UtcNow;
+
+    public void Abandon(string receiptId) => _receipts.TryRemove(receiptId, out _);
+
+    private void RemoveExpiredReceipts()
+    {
+        var cutoff = DateTimeOffset.UtcNow - Retention;
+        foreach (var receipt in _receipts.Where(item => item.Value < cutoff))
+        {
+            _receipts.TryRemove(receipt.Key, out _);
+        }
+
+        if (_receipts.Count < MaximumReceipts)
+        {
+            return;
+        }
+
+        foreach (var receipt in _receipts
+                     .OrderBy(item => item.Value)
+                     .Take(_receipts.Count - MaximumReceipts + 1))
+        {
+            _receipts.TryRemove(receipt.Key, out _);
+        }
+    }
+}

--- a/PayBridge.SDK.Test/Unit/SecureWebhookControllerTests.cs
+++ b/PayBridge.SDK.Test/Unit/SecureWebhookControllerTests.cs
@@ -81,6 +81,7 @@ public class SecureWebhookControllerTests
             paymentService,
             verifier,
             new OrderService(),
+            new WebhookReplayStore(),
             NullLogger<WebhookController>.Instance)
         {
             ControllerContext = new ControllerContext

--- a/PayBridge.SDK.Test/Unit/WebhookReplayStoreTests.cs
+++ b/PayBridge.SDK.Test/Unit/WebhookReplayStoreTests.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+using PayBridge.SDK.Enums;
+using PayBridge.SDK.Example.Services;
+using Xunit;
+
+namespace PayBridge.SDK.Test.Unit;
+
+[Trait("Category", "Unit")]
+public class WebhookReplayStoreTests
+{
+    [Fact]
+    public void Concurrent_identical_deliveries_allow_only_one_processor()
+    {
+        var store = new WebhookReplayStore();
+        var payload = "signed-provider-payload"u8.ToArray();
+
+        var accepted = Enumerable.Range(0, 16)
+            .AsParallel()
+            .Select(index => store.TryStart(
+                PaymentGatewayType.Paystack,
+                payload,
+                out var receiptId))
+            .ToArray();
+
+        accepted.Count(value => value).Should().Be(1);
+    }
+
+    [Fact]
+    public void Abandoned_delivery_can_be_retried()
+    {
+        var store = new WebhookReplayStore();
+        var payload = "signed-provider-payload"u8.ToArray();
+        store.TryStart(PaymentGatewayType.Paystack, payload, out var receiptId)
+            .Should().BeTrue();
+
+        store.Abandon(receiptId);
+
+        store.TryStart(PaymentGatewayType.Paystack, payload, out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Repeated_fulfillment_does_not_change_the_paid_timestamp()
+    {
+        var orders = new OrderService();
+        var order = orders.Create("customer@example.test", 100m, "NGN", "Order");
+        orders.MarkAsPaid(order.OrderId, "PAY-1").Should().BeTrue();
+        var paidAt = order.PaidAt;
+
+        orders.MarkAsPaid(order.OrderId, "PAY-1").Should().BeTrue();
+
+        order.PaidAt.Should().Be(paidAt);
+    }
+}

--- a/docs/webhook-replay-protection.md
+++ b/docs/webhook-replay-protection.md
@@ -1,0 +1,16 @@
+# Webhook replay protection
+
+The example webhook verifies the provider signature before calculating a replay
+receipt. The receipt is a SHA-256 hash of the authenticated provider and exact
+raw request body. Only one concurrent delivery can begin processing a receipt.
+
+Completed receipts are retained for 24 hours and the example store is capped at
+10,000 entries. Failed verification or order matching abandons the receipt so a
+provider retry can be processed again. Successful fulfillment retains it, and
+`OrderService.MarkAsPaid` is independently idempotent.
+
+`WebhookReplayStore` is intentionally an in-memory example. Production systems
+must implement the same atomic `TryStart`, `Complete`, and `Abandon` contract in
+a shared durable store so protection survives restarts and works across service
+instances. Receipt retention should be at least as long as each provider's
+documented webhook retry window.


### PR DESCRIPTION
## Summary
- atomically suppress concurrent and repeated authenticated webhook deliveries
- hash the provider plus exact signed request body into a replay receipt
- abandon failed processing so legitimate provider retries remain possible
- make example order fulfillment idempotent
- bound in-memory receipts to 24 hours and 10,000 entries
- document the production requirement for a shared durable implementation

## Security boundary
Replay receipts are created only after provider signature verification. The example store is intentionally process-local and is not presented as cross-instance durability; production integrations must implement the same atomic contract in shared storage.

## Validation
- focused replay/security suite: 5 passed
- full suite: 142 passed, 3 opt-in sandbox tests skipped
- Release build: 0 warnings, 0 errors

Part of #64