### PR TITLE
Make automatic gateway routing deterministic and safe

### DIFF
--- a/PayBridge.SDK.Test/Unit/IServiceCollectionExtensionsTests.cs
+++ b/PayBridge.SDK.Test/Unit/IServiceCollectionExtensionsTests.cs
@@ -17,7 +17,7 @@ public class IServiceCollectionExtensionsTests
     {
         var configuration = BuildConfiguration(new Dictionary<string, string?>
         {
-            ["PaymentGatewayConfig:DefaultGateway"] = "Stripe",
+            ["PaymentGatewayConfig:DefaultGateway"] = "Paystack",
             ["PaymentGatewayConfig:EnabledGateways:0"] = "Paystack",
             ["PaymentGatewayConfig:Paystack:SecretKey"] = "sk_from_config"
         });
@@ -35,7 +35,7 @@ public class IServiceCollectionExtensionsTests
         var config = provider.GetRequiredService<PaymentGatewayConfig>();
         var options = provider.GetRequiredService<IOptions<PaymentGatewayConfig>>();
 
-        config.DefaultGateway.Should().Be(PaymentGatewayType.Stripe);
+        config.DefaultGateway.Should().Be(PaymentGatewayType.Paystack);
         config.EnabledGateways.Should().ContainSingle().Which.Should().Be(PaymentGatewayType.Paystack);
         config.Paystack.SecretKey.Should().Be("sk_from_code");
         options.Value.Should().BeSameAs(config);
@@ -101,6 +101,73 @@ public class IServiceCollectionExtensionsTests
         using var provider = services.BuildServiceProvider();
         provider.GetRequiredService<IWebhookSignatureVerifier>().Should().NotBeNull();
         provider.GetRequiredService<TimeProvider>().Should().BeSameAs(customTimeProvider);
+    }
+
+    [Fact]
+    public void AddPayBridge_WhenEnabledGatewayIsMissingRequiredConfig_Throws()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["PaymentGatewayConfig:EnabledGateways:0"] = "Paystack"
+        });
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var action = () => services.AddPayBridge(configuration);
+
+        action.Should().Throw<Exception>()
+            .WithMessage("*Paystack*missing required configuration*");
+    }
+
+    [Fact]
+    public void AddPayBridge_WhenEnabledGatewaysContainsAutomatic_Throws()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["PaymentGatewayConfig:EnabledGateways:0"] = "Automatic"
+        });
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var action = () => services.AddPayBridge(configuration);
+
+        action.Should().Throw<Exception>()
+            .WithMessage("*cannot include Automatic*");
+    }
+
+    [Fact]
+    public void AddPayBridge_WhenDefaultGatewayIsMissingRequiredConfig_Throws()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["PaymentGatewayConfig:DefaultGateway"] = "Paystack"
+        });
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var action = () => services.AddPayBridge(configuration);
+
+        action.Should().Throw<Exception>()
+            .WithMessage("*Default gateway*Paystack*missing required configuration*");
+    }
+
+    [Fact]
+    public void AddPayBridge_WhenDefaultGatewayIsNotInEnabledGateways_Throws()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["PaymentGatewayConfig:DefaultGateway"] = "Stripe",
+            ["PaymentGatewayConfig:EnabledGateways:0"] = "Paystack",
+            ["PaymentGatewayConfig:Stripe:SecretKey"] = "sk_test_stripe",
+            ["PaymentGatewayConfig:Paystack:SecretKey"] = "sk_test_paystack"
+        });
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var action = () => services.AddPayBridge(configuration);
+
+        action.Should().Throw<Exception>()
+            .WithMessage("*Default gateway*Stripe*must be included in EnabledGateways*");
     }
 
     [Fact]

--- a/PayBridge.SDK.Test/Unit/PaymentServiceRoutingTests.cs
+++ b/PayBridge.SDK.Test/Unit/PaymentServiceRoutingTests.cs
@@ -1,0 +1,127 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using PayBridge.SDK.Application.Dtos;
+using PayBridge.SDK.Dtos.Request;
+using PayBridge.SDK.Dtos.Response;
+using PayBridge.SDK.Enums;
+using PayBridge.SDK.Interfaces;
+using Xunit;
+
+namespace PayBridge.SDK.Test.Unit;
+
+[Trait("Category", "Unit")]
+public class PaymentServiceRoutingTests
+{
+    [Fact]
+    public async Task Automatic_routing_honors_compatible_configured_default()
+    {
+        var stripe = Gateway(PaymentGatewayType.Stripe);
+        var checkout = Gateway(PaymentGatewayType.Checkout);
+        var service = CreateService(
+            new PaymentGatewayConfig { DefaultGateway = PaymentGatewayType.Checkout },
+            stripe.Object,
+            checkout.Object);
+
+        await service.CreatePaymentAsync(Request("USD"));
+
+        checkout.Verify(item => item.CreatePaymentAsync(It.IsAny<PaymentRequest>()), Times.Once);
+        stripe.Verify(item => item.CreatePaymentAsync(It.IsAny<PaymentRequest>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Automatic_routing_is_deterministic_across_registration_order()
+    {
+        var stripe = Gateway(PaymentGatewayType.Stripe);
+        var checkout = Gateway(PaymentGatewayType.Checkout);
+        var service = CreateService(new PaymentGatewayConfig(), checkout.Object, stripe.Object);
+
+        await service.CreatePaymentAsync(Request("USD"));
+
+        stripe.Verify(item => item.CreatePaymentAsync(It.IsAny<PaymentRequest>()), Times.Once);
+        checkout.Verify(item => item.CreatePaymentAsync(It.IsAny<PaymentRequest>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Incompatible_default_is_skipped_for_compatible_gateway()
+    {
+        var stripe = Gateway(PaymentGatewayType.Stripe);
+        var paystack = Gateway(PaymentGatewayType.Paystack);
+        var service = CreateService(
+            new PaymentGatewayConfig { DefaultGateway = PaymentGatewayType.Paystack },
+            paystack.Object,
+            stripe.Object);
+
+        await service.CreatePaymentAsync(Request("USD"));
+
+        stripe.Verify(item => item.CreatePaymentAsync(It.IsAny<PaymentRequest>()), Times.Once);
+        paystack.Verify(item => item.CreatePaymentAsync(It.IsAny<PaymentRequest>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Single_incompatible_gateway_does_not_bypass_routing_rules()
+    {
+        var checkout = Gateway(PaymentGatewayType.Checkout);
+        var service = CreateService(new PaymentGatewayConfig(), checkout.Object);
+
+        var action = () => service.CreatePaymentAsync(Request("NGN"));
+
+        await action.Should().ThrowAsync<Exception>().WithMessage("*supports NGN*");
+        checkout.Verify(item => item.CreatePaymentAsync(It.IsAny<PaymentRequest>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData("ZZZ", PaymentMethodType.Card)]
+    [InlineData("USD", PaymentMethodType.Crypto)]
+    public async Task Unsupported_routes_fail_before_provider_call(
+        string currency,
+        PaymentMethodType method)
+    {
+        var stripe = Gateway(PaymentGatewayType.Stripe);
+        var service = CreateService(new PaymentGatewayConfig(), stripe.Object);
+        var request = Request(currency);
+        request.PaymentMethodType = method;
+
+        var action = () => service.CreatePaymentAsync(request);
+
+        await action.Should().ThrowAsync<Exception>().WithMessage("*supports*");
+        stripe.Verify(item => item.CreatePaymentAsync(It.IsAny<PaymentRequest>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Stripe_routes_documented_JPY_currency()
+    {
+        var stripe = Gateway(PaymentGatewayType.Stripe);
+        var service = CreateService(new PaymentGatewayConfig(), stripe.Object);
+
+        await service.CreatePaymentAsync(Request("JPY"));
+
+        stripe.Verify(item => item.CreatePaymentAsync(It.IsAny<PaymentRequest>()), Times.Once);
+    }
+
+    private static PaymentService CreateService(
+        PaymentGatewayConfig config,
+        params IPaymentGateway[] gateways) =>
+        new(
+            Mock.Of<ITransactionRepository>(),
+            Mock.Of<IRefundRepository>(),
+            gateways,
+            NullLogger<PaymentService>.Instance,
+            config);
+
+    private static Mock<IPaymentGateway> Gateway(PaymentGatewayType type)
+    {
+        var gateway = new Mock<IPaymentGateway>();
+        gateway.SetupGet(item => item.GatewayType).Returns(type);
+        gateway.Setup(item => item.CreatePaymentAsync(It.IsAny<PaymentRequest>()))
+            .ReturnsAsync(new PaymentResponse { Success = false, Status = PaymentStatus.Failed });
+        return gateway;
+    }
+
+    private static PaymentRequest Request(string currency) => new()
+    {
+        Amount = 100m,
+        Currency = currency,
+        CustomerEmail = "customer@example.test"
+    };
+}

--- a/PayBridge.SDK.Test/Unit/PaymentServiceRoutingTests.cs
+++ b/PayBridge.SDK.Test/Unit/PaymentServiceRoutingTests.cs
@@ -59,6 +59,19 @@ public class PaymentServiceRoutingTests
     }
 
     [Fact]
+    public async Task Unregistered_compatible_default_is_skipped()
+    {
+        var stripe = Gateway(PaymentGatewayType.Stripe);
+        var service = CreateService(
+            new PaymentGatewayConfig { DefaultGateway = PaymentGatewayType.Checkout },
+            stripe.Object);
+
+        await service.CreatePaymentAsync(Request("USD"));
+
+        stripe.Verify(item => item.CreatePaymentAsync(It.IsAny<PaymentRequest>()), Times.Once);
+    }
+
+    [Fact]
     public async Task Single_incompatible_gateway_does_not_bypass_routing_rules()
     {
         var checkout = Gateway(PaymentGatewayType.Checkout);
@@ -106,6 +119,45 @@ public class PaymentServiceRoutingTests
         await service.CreatePaymentAsync(Request("JPY"));
 
         stripe.Verify(item => item.CreatePaymentAsync(It.IsAny<PaymentRequest>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Automatic_routing_trims_currency_before_matching()
+    {
+        var stripe = Gateway(PaymentGatewayType.Stripe);
+        var service = CreateService(new PaymentGatewayConfig(), stripe.Object);
+
+        await service.CreatePaymentAsync(Request(" usd "));
+
+        stripe.Verify(item => item.CreatePaymentAsync(It.IsAny<PaymentRequest>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Explicit_gateway_rejects_crypto_before_provider_call()
+    {
+        var stripe = Gateway(PaymentGatewayType.Stripe);
+        var service = CreateService(new PaymentGatewayConfig(), stripe.Object);
+        var request = Request("USD");
+        request.PaymentMethodType = PaymentMethodType.Crypto;
+
+        var action = () => service.CreatePaymentAsync(request, PaymentGatewayType.Stripe);
+
+        await action.Should().ThrowAsync<Exception>()
+            .WithMessage("*payment method Crypto*");
+        stripe.Verify(item => item.CreatePaymentAsync(It.IsAny<PaymentRequest>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Unsupported_currency_message_uses_trimmed_normalized_currency()
+    {
+        var stripe = Gateway(PaymentGatewayType.Stripe);
+        var service = CreateService(new PaymentGatewayConfig(), stripe.Object);
+
+        var action = () => service.CreatePaymentAsync(Request(" zzz "));
+
+        await action.Should().ThrowAsync<Exception>()
+            .WithMessage("*supports ZZZ*");
+        stripe.Verify(item => item.CreatePaymentAsync(It.IsAny<PaymentRequest>()), Times.Never);
     }
 
     [Fact]

--- a/PayBridge.SDK.Test/Unit/PaymentServiceRoutingTests.cs
+++ b/PayBridge.SDK.Test/Unit/PaymentServiceRoutingTests.cs
@@ -73,6 +73,11 @@ public class PaymentServiceRoutingTests
     [Theory]
     [InlineData("ZZZ", PaymentMethodType.Card)]
     [InlineData("USD", PaymentMethodType.Crypto)]
+    [InlineData("NGN", PaymentMethodType.BankTransfer)]
+    [InlineData("KES", PaymentMethodType.MobileMoney)]
+    [InlineData("USD", PaymentMethodType.Wallet)]
+    [InlineData("NGN", PaymentMethodType.Ussd)]
+    [InlineData("NGN", PaymentMethodType.QrCode)]
     public async Task Unsupported_routes_fail_before_provider_call(
         string currency,
         PaymentMethodType method)
@@ -84,7 +89,11 @@ public class PaymentServiceRoutingTests
 
         var action = () => service.CreatePaymentAsync(request);
 
-        await action.Should().ThrowAsync<Exception>().WithMessage("*supports*");
+        var exception = await action.Should().ThrowAsync<Exception>();
+        var message = exception.Which.Message;
+        (message.Contains("supports", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("Specify a gateway explicitly", StringComparison.OrdinalIgnoreCase))
+            .Should().BeTrue();
         stripe.Verify(item => item.CreatePaymentAsync(It.IsAny<PaymentRequest>()), Times.Never);
     }
 
@@ -97,6 +106,42 @@ public class PaymentServiceRoutingTests
         await service.CreatePaymentAsync(Request("JPY"));
 
         stripe.Verify(item => item.CreatePaymentAsync(It.IsAny<PaymentRequest>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Automatic_routing_rejects_saved_payment_method_until_binding_is_implemented()
+    {
+        var stripe = Gateway(PaymentGatewayType.Stripe);
+        var service = CreateService(new PaymentGatewayConfig(), stripe.Object);
+        var request = Request("USD");
+        request.SavedPaymentMethodId = "pm_saved_123";
+
+        var action = () => service.CreatePaymentAsync(request);
+
+        await action.Should().ThrowAsync<Exception>()
+            .WithMessage("*Saved payment method routing is not yet implemented*");
+        stripe.Verify(item => item.CreatePaymentAsync(It.IsAny<PaymentRequest>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Verify_automatic_routing_rejects_unknown_reference_prefix()
+    {
+        var stripe = Gateway(PaymentGatewayType.Stripe);
+        var transactionRepository = new Mock<ITransactionRepository>();
+        transactionRepository.Setup(repository => repository.GetByReferenceAsync("UNKNOWN_123"))
+            .ReturnsAsync((PayBridge.SDK.Entities.PaymentTransaction?)null);
+        var service = new PaymentService(
+            transactionRepository.Object,
+            Mock.Of<IRefundRepository>(),
+            [stripe.Object],
+            NullLogger<PaymentService>.Instance,
+            new PaymentGatewayConfig { DefaultGateway = PaymentGatewayType.Stripe });
+
+        var action = () => service.VerifyPaymentAsync("UNKNOWN_123");
+
+        await action.Should().ThrowAsync<Exception>()
+            .WithMessage("*Unable to determine gateway from transaction reference*");
+        stripe.Verify(item => item.VerifyPaymentAsync(It.IsAny<string>()), Times.Never);
     }
 
     private static PaymentService CreateService(
@@ -115,6 +160,8 @@ public class PaymentServiceRoutingTests
         gateway.SetupGet(item => item.GatewayType).Returns(type);
         gateway.Setup(item => item.CreatePaymentAsync(It.IsAny<PaymentRequest>()))
             .ReturnsAsync(new PaymentResponse { Success = false, Status = PaymentStatus.Failed });
+        gateway.Setup(item => item.VerifyPaymentAsync(It.IsAny<string>()))
+            .ReturnsAsync(new VerificationResponse { Success = false, Status = PaymentStatus.Failed });
         return gateway;
     }
 

--- a/PayBridge.SDK/Externsions/IServiceCollectionExtensions.cs
+++ b/PayBridge.SDK/Externsions/IServiceCollectionExtensions.cs
@@ -1,10 +1,11 @@
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using PayBridge.SDK.Application.Dtos;
 using PayBridge.SDK.Enums;
+using PayBridge.SDK.Exceptions;
 using PayBridge.SDK.Interfaces;
 using PayBridge.SDK.Services;
 
@@ -125,6 +126,8 @@ public static class IServiceCollectionExtensions
         configuration?.GetSection("PaymentGatewayConfig").Bind(config);
         configAction?.Invoke(config);
 
+        ValidateDefaultGatewayConfiguration(config);
+
         services.AddSingleton(config);
         services.AddSingleton<IOptions<PaymentGatewayConfig>>(Options.Create(config));
 
@@ -164,10 +167,51 @@ public static class IServiceCollectionExtensions
             return;
         }
 
+        ValidateEnabledGatewayConfiguration(config);
+
         // Register only the enabled gateways
         foreach (var gateway in config.EnabledGateways)
         {
             RegisterGateway(services, gateway);
+        }
+    }
+
+    private static void ValidateEnabledGatewayConfiguration(PaymentGatewayConfig config)
+    {
+        foreach (var gateway in config.EnabledGateways)
+        {
+            if (gateway == PaymentGatewayType.Automatic)
+            {
+                throw new PaymentConfigurationException(
+                    "PaymentGatewayConfig:EnabledGateways cannot include Automatic. " +
+                    "Use concrete gateway types only.");
+            }
+
+            if (!IsGatewayConfigured(config, gateway))
+            {
+                throw new PaymentConfigurationException(
+                    $"Enabled gateway '{gateway}' is missing required configuration values.");
+            }
+        }
+    }
+
+    private static void ValidateDefaultGatewayConfiguration(PaymentGatewayConfig config)
+    {
+        if (config.DefaultGateway == PaymentGatewayType.Automatic)
+        {
+            return;
+        }
+
+        if (!IsGatewayConfigured(config, config.DefaultGateway))
+        {
+            throw new PaymentConfigurationException(
+                $"Default gateway '{config.DefaultGateway}' is missing required configuration values.");
+        }
+
+        if (config.EnabledGateways.Count > 0 && !config.EnabledGateways.Contains(config.DefaultGateway))
+        {
+            throw new PaymentConfigurationException(
+                $"Default gateway '{config.DefaultGateway}' must be included in EnabledGateways when explicit gateway registration is used.");
         }
     }
 

--- a/PayBridge.SDK/Services/PaymentService.cs
+++ b/PayBridge.SDK/Services/PaymentService.cs
@@ -441,11 +441,19 @@ public class PaymentService : IPaymentService
                 "No configured gateway supports payment method Crypto.");
         }
 
+        if (request.PaymentMethodType != PaymentMethodType.Card)
+        {
+            throw new PaymentGatewayException(
+                $"Automatic routing for payment method {request.PaymentMethodType} " +
+                "is not yet implemented. Specify a gateway explicitly.");
+        }
+
         // Check for saved payment method - must use the same gateway
         if (!string.IsNullOrEmpty(request.SavedPaymentMethodId))
         {
-            // TODO: Lookup saved payment method and return its gateway
-            // For now, fall through to other selection logic
+            throw new PaymentGatewayException(
+                "Saved payment method routing is not yet implemented. " +
+                "Specify a gateway explicitly until provider binding is available.");
         }
 
         // Select based on currency
@@ -580,9 +588,9 @@ public class PaymentService : IPaymentService
         {
             return PaymentGatewayType.PeachPayments;
         }
-        // Default to configured default gateway
-        _logger.LogWarning("Could not determine gateway from reference: {Reference}", transactionReference);
-        return _config.DefaultGateway;
+        throw new PaymentGatewayException(
+            $"Unable to determine gateway from transaction reference '{transactionReference}'. " +
+            "Specify a gateway explicitly for verification.");
     }
 
     private void ValidateRequest(PaymentRequest request)

--- a/PayBridge.SDK/Services/PaymentService.cs
+++ b/PayBridge.SDK/Services/PaymentService.cs
@@ -435,12 +435,10 @@ public class PaymentService : IPaymentService
 
     private PaymentGatewayType SelectBestGateway(PaymentRequest request)
     {
-        // Logic to determine best gateway based on various factors
-
-        // If only one gateway is enabled, use that
-        if (_gateways.Count == 1)
+        if (request.PaymentMethodType == PaymentMethodType.Crypto)
         {
-            return _gateways.Keys.First();
+            throw new PaymentGatewayException(
+                "No configured gateway supports payment method Crypto.");
         }
 
         // Check for saved payment method - must use the same gateway
@@ -451,56 +449,58 @@ public class PaymentService : IPaymentService
         }
 
         // Select based on currency
-        switch (request.Currency?.ToUpper())
+        var compatibleGateways = request.Currency.ToUpperInvariant() switch
         {
-            case "NGN":
-                return ChooseAvailableGateway(PaymentGatewayType.Monnify, PaymentGatewayType.Squad, PaymentGatewayType.Korapay, PaymentGatewayType.Interswitch, PaymentGatewayType.Remita, PaymentGatewayType.Opay, PaymentGatewayType.Paystack, PaymentGatewayType.Flutterwave);
+            "NGN" => new[] { PaymentGatewayType.Monnify, PaymentGatewayType.Squad, PaymentGatewayType.Korapay, PaymentGatewayType.Interswitch, PaymentGatewayType.Remita, PaymentGatewayType.Opay, PaymentGatewayType.Paystack, PaymentGatewayType.Flutterwave },
+            "KES" or "GHS" or "UGX" or "TZS" or "ZAR" or "RWF" or "ZMW" or
+                "CDF" or "XOF" or "XAF" or "MWK" =>
+                [PaymentGatewayType.PeachPayments, PaymentGatewayType.PawaPay, PaymentGatewayType.DpoGroup, PaymentGatewayType.Flutterwave, PaymentGatewayType.Paystack],
+            "BWP" => [PaymentGatewayType.PeachPayments, PaymentGatewayType.DpoGroup],
+            "BHD" => [PaymentGatewayType.BenefitPay],
+            "KWD" => [PaymentGatewayType.Knet],
+            "USD" or "EUR" or "GBP" => [PaymentGatewayType.Stripe, PaymentGatewayType.Checkout],
+            "JPY" => [PaymentGatewayType.Stripe],
+            _ => []
+        };
 
-            case "KES":
-            case "GHS":
-            case "UGX":
-            case "TZS":
-            case "ZAR":
-            case "RWF":
-            case "ZMW":
-            case "CDF":
-            case "XOF":
-            case "XAF":
-            case "MWK":
-                return ChooseAvailableGateway(PaymentGatewayType.PeachPayments, PaymentGatewayType.PawaPay, PaymentGatewayType.DpoGroup, PaymentGatewayType.Flutterwave, PaymentGatewayType.Paystack);
-
-            case "BWP":
-                return ChooseAvailableGateway(PaymentGatewayType.PeachPayments, PaymentGatewayType.DpoGroup);
-
-            case "BHD":
-                return ChooseAvailableGateway(PaymentGatewayType.BenefitPay);
-
-            case "KWD":
-                return ChooseAvailableGateway(PaymentGatewayType.Knet);
-
-            case "USD":
-            case "EUR":
-            case "GBP":
-            default:
-                return ChooseAvailableGateway(PaymentGatewayType.Stripe, PaymentGatewayType.Checkout);
-        }
+        return ChooseAvailableGateway(request, compatibleGateways);
     }
 
     #region [Private Methods]
 
-    private PaymentGatewayType ChooseAvailableGateway(params PaymentGatewayType[] preferredGateways)
+    private PaymentGatewayType ChooseAvailableGateway(
+        PaymentRequest request,
+        IReadOnlyCollection<PaymentGatewayType> compatibleGateways)
     {
+        if (_config.DefaultGateway != PaymentGatewayType.Automatic &&
+            compatibleGateways.Contains(_config.DefaultGateway) &&
+            _gateways.ContainsKey(_config.DefaultGateway))
+        {
+            _logger.LogInformation(
+                "Selected configured default gateway {Gateway} for {Currency} and {PaymentMethod}",
+                _config.DefaultGateway,
+                request.Currency,
+                request.PaymentMethodType);
+            return _config.DefaultGateway;
+        }
+
         // Try each gateway in order of preference
-        foreach (var gateway in preferredGateways)
+        foreach (var gateway in compatibleGateways)
         {
             if (_gateways.ContainsKey(gateway))
             {
+                _logger.LogInformation(
+                    "Selected compatible gateway {Gateway} for {Currency} and {PaymentMethod}",
+                    gateway,
+                    request.Currency,
+                    request.PaymentMethodType);
                 return gateway;
             }
         }
 
-        // Fall back to the first available gateway
-        return _gateways.Keys.First();
+        throw new PaymentGatewayException(
+            $"No configured gateway supports {request.Currency.ToUpperInvariant()} " +
+            $"with payment method {request.PaymentMethodType}.");
     }
 
     private PaymentGatewayType DetermineGatewayFromReference(string transactionReference)

--- a/PayBridge.SDK/Services/PaymentService.cs
+++ b/PayBridge.SDK/Services/PaymentService.cs
@@ -45,6 +45,13 @@ public class PaymentService : IPaymentService
     public async Task<PaymentResponse> CreatePaymentAsync(PaymentRequest request, PaymentGatewayType gateway = PaymentGatewayType.Automatic)
     {
         ValidateRequest(request);
+        request.Currency = NormalizeCurrency(request.Currency);
+
+        if (request.PaymentMethodType == PaymentMethodType.Crypto)
+        {
+            throw new PaymentGatewayException(
+                "No configured gateway supports payment method Crypto.");
+        }
 
         if (_gateways.Count == 0)
         {
@@ -435,12 +442,6 @@ public class PaymentService : IPaymentService
 
     private PaymentGatewayType SelectBestGateway(PaymentRequest request)
     {
-        if (request.PaymentMethodType == PaymentMethodType.Crypto)
-        {
-            throw new PaymentGatewayException(
-                "No configured gateway supports payment method Crypto.");
-        }
-
         if (request.PaymentMethodType != PaymentMethodType.Card)
         {
             throw new PaymentGatewayException(
@@ -457,7 +458,8 @@ public class PaymentService : IPaymentService
         }
 
         // Select based on currency
-        var compatibleGateways = request.Currency.ToUpperInvariant() switch
+        var currency = NormalizeCurrency(request.Currency);
+        var compatibleGateways = currency switch
         {
             "NGN" => new[] { PaymentGatewayType.Monnify, PaymentGatewayType.Squad, PaymentGatewayType.Korapay, PaymentGatewayType.Interswitch, PaymentGatewayType.Remita, PaymentGatewayType.Opay, PaymentGatewayType.Paystack, PaymentGatewayType.Flutterwave },
             "KES" or "GHS" or "UGX" or "TZS" or "ZAR" or "RWF" or "ZMW" or
@@ -507,9 +509,12 @@ public class PaymentService : IPaymentService
         }
 
         throw new PaymentGatewayException(
-            $"No configured gateway supports {request.Currency.ToUpperInvariant()} " +
+            $"No configured gateway supports {NormalizeCurrency(request.Currency)} " +
             $"with payment method {request.PaymentMethodType}.");
     }
+
+    private static string NormalizeCurrency(string currency) =>
+        currency.Trim().ToUpperInvariant();
 
     private PaymentGatewayType DetermineGatewayFromReference(string transactionReference)
     {

--- a/docs/automatic-gateway-routing.md
+++ b/docs/automatic-gateway-routing.md
@@ -5,6 +5,10 @@ compatibility list. A configured `DefaultGateway` is selected when it is both
 registered and compatible; otherwise PayBridge uses the deterministic order for
 that currency. DI registration order does not affect the result.
 
+Automatic routing currently supports `PaymentMethodType.Card` only. For
+`BankTransfer`, `MobileMoney`, `Wallet`, `Ussd`, and `QrCode`, specify a
+concrete gateway explicitly in the payment request.
+
 PayBridge rejects unknown currencies, unsupported payment methods, and cases
 where no compatible gateway is configured before making a provider request. It
 does not fall back to an arbitrary registered gateway.

--- a/docs/automatic-gateway-routing.md
+++ b/docs/automatic-gateway-routing.md
@@ -1,0 +1,25 @@
+# Automatic gateway routing
+
+Automatic routing considers only configured gateways in the currency's declared
+compatibility list. A configured `DefaultGateway` is selected when it is both
+registered and compatible; otherwise PayBridge uses the deterministic order for
+that currency. DI registration order does not affect the result.
+
+PayBridge rejects unknown currencies, unsupported payment methods, and cases
+where no compatible gateway is configured before making a provider request. It
+does not fall back to an arbitrary registered gateway.
+
+Current currency groups are:
+
+- NGN: Monnify, Squad, Korapay, Interswitch, Remita, OPay, Paystack, Flutterwave
+- KES/GHS/UGX/TZS/ZAR/RWF/ZMW/CDF/XOF/XAF/MWK: Peach Payments, pawaPay, DPO,
+  Flutterwave, Paystack
+- BWP: Peach Payments, DPO
+- BHD: BenefitPay
+- KWD: KNET
+- USD/EUR/GBP: Stripe, Checkout.com
+- JPY: Stripe
+
+Cryptocurrency is not implemented by any current PayBridge gateway and is
+rejected explicitly. Provider capability metadata for finer payment-method and
+regional routing remains tracked by issue #90.


### PR DESCRIPTION
## Summary
- honor `DefaultGateway` only when it is registered and compatible
- remove registration-order and single-gateway routing bypasses
- reject unknown currencies and unsupported cryptocurrency routes before provider calls
- retain deterministic preferences for documented currency groups
- add structured selection logs without customer or credential data
- document routing rules and the remaining capability-metadata boundary

## Root cause
Automatic routing ignored `DefaultGateway`, treated every unknown currency as a Stripe/Checkout currency, and fell back to the first DI-registered gateway when no preferred provider was available. This could invoke a provider that could not process the request.

## Validation
- routing suite covers compatible/incompatible defaults, registration order, single-gateway bypass, JPY, unknown currency, and unsupported method cases
- full suite: 149 passed, 3 opt-in sandbox tests skipped
- Release build: 0 warnings, 0 errors

Part of #65
Related to #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic gateway routing now uses only compatible gateways per currency (and supports deterministic priority), including normalized/trimmed currency matching.
  * Configured default gateways are honored only when compatible; otherwise routing follows deterministic order.
  * Crypto and unsupported payment methods/currencies are rejected before provider calls; unknown reference prefixes now require explicit gateway selection.
  * Saved payment methods are rejected until binding is implemented.
* **Documentation**
  * Added guidance for automatic gateway routing rules and rejection conditions.
* **Tests**
  * Expanded routing and selection test coverage (including deterministic behavior, currency normalization, and JPY documentation). 
* **Bug Fixes**
  * Improved configuration validation for enabled/default gateways with clearer failure messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->