### PR TITLE
Docs: align README and NuGet claims with current SDK state (#84)

### DIFF
--- a/PayBridge.SDK/PayBridge.SDK.csproj
+++ b/PayBridge.SDK/PayBridge.SDK.csproj
@@ -10,7 +10,7 @@
 	<FileVersion>1.2.0</FileVersion>
 	<Authors>Babatunde Esanju</Authors>
 	<Company>Teesoftech</Company>
-	<PackageDescription>Seamlessly integrate multiple payment gateways into your ASP.NET Core applications. v1.2.0 adds PeachPayments gateway, a full xUnit test suite (76 tests), CI/CD workflows, and codebase-wide nullable safety fixes.</PackageDescription>
+  <PackageDescription>Seamlessly integrate multiple payment gateways into your ASP.NET Core applications with secure webhook verification, deterministic routing, and built-in persistence support.</PackageDescription>
 	<Description>Seamlessly integrate multiple payment gateways into your ASP.NET Core applications.</Description>
 	<PackageTags>payments; aspnetcore; fintech; sdk; paybridge; nigeria; africa; flutterwave; paystack; stripe; monnify; opay; remita; interswitch; korapay; pawapay; dpo; peachpayments; southafrica</PackageTags>
 	<RepositoryUrl>https://github.com/teesofttech/PayBridge</RepositoryUrl>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/teesofttech/PayBridge/issues">
     <img src="https://img.shields.io/github/issues/teesofttech/PayBridge" alt="Issues">
   </a>
-  <a href="https://github.com/teesofttech/PayBridge/blob/main/LICENSE">
+  <a href="https://github.com/teesofttech/PayBridge/blob/master/LICENSE">
     <img src="https://img.shields.io/github/license/teesofttech/PayBridge" alt="License">
   </a>
 </p>
@@ -29,7 +29,7 @@
 
 ## 🚀 Features
 
-- **Unified API**: Interact with multiple payment gateways (e.g., Flutterwave, Paystack, Fincra, Stripe, Korapay) through a single, consistent interface.
+- **Unified API**: Interact with multiple payment gateways (e.g., Flutterwave, Paystack, Stripe, Korapay, PeachPayments) through a single, consistent interface.
 - **Database Flexibility**: Choose between PayBridge's default database or integrate with your own.
 - **Transaction Logging**: Automatically records transaction details for auditing and reporting.
 - **Extensible Architecture**: Built with Clean Architecture principles for maintainability and scalability.
@@ -278,6 +278,6 @@ git push origin feature/your-feature-name
 
 ## 📄 License
 
-PayBridge is released under the [MIT License](https://github.com/teesofttech/PayBridge/blob/main/LICENSE).
+PayBridge is released under the [MIT License](https://github.com/teesofttech/PayBridge/blob/master/LICENSE).
 
 > You're free to use, modify, and distribute this software as long as the original license is included.

--- a/README.nuget.md
+++ b/README.nuget.md
@@ -4,14 +4,14 @@
 
 [![NuGet](https://img.shields.io/nuget/v/PayBridge.SDK)](https://www.nuget.org/packages/PayBridge.SDK)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/PayBridge.SDK)](https://www.nuget.org/packages/PayBridge.SDK)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/teesofttech/PayBridge/blob/main/LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/teesofttech/PayBridge/blob/master/LICENSE)
 [![GitHub](https://img.shields.io/badge/GitHub-teesofttech%2FPayBridge-blue)](https://github.com/teesofttech/PayBridge)
 
 ---
 
 ## What is PayBridge?
 
-PayBridge.SDK is an open-source .NET 8 library that provides a **single, unified interface** to 14+ payment gateways across Nigeria, Africa, and globally. Stop writing gateway-specific code — define your payment logic once and switch providers with a single configuration change.
+PayBridge.SDK is an open-source .NET 8 library that provides a **single, unified interface** to 15 payment gateways across Nigeria, Africa, and globally. Stop writing gateway-specific code — define your payment logic once and switch providers with a single configuration change.
 
 ---
 
@@ -33,17 +33,18 @@ PayBridge.SDK is an open-source .NET 8 library that provides a **single, unified
 | **PawaPay** | Africa (mobile money) | GHS, TZS, UGX, RWF, ZMW, … | REST ******
 | **BenefitPay** | Bahrain / GCC | BHD | Merchant API |
 | **Knet** | Kuwait | KWD | Transport Key |
+| **Peach Payments** | South Africa / Kenya / Nigeria / Botswana | ZAR, KES, NGN, BWP, USD | Bearer AccessToken + EntityId |
 
 ---
 
 ## Features
 
-- ✅ **Unified API** — one interface for all gateways: create, verify, and refund payments
+- ✅ **Unified API** — one interface across supported gateways for create, verify, and refund operations
 - ✅ **Smart Routing** — `Automatic` mode picks the best gateway based on currency
 - ✅ **Transaction Logging** — built-in persistence for auditing and reporting
 - ✅ **Multi-database Support** — SQL Server, PostgreSQL, MySQL, SQLite
 - ✅ **Clean Architecture** — repository pattern, DI-friendly, extensible
-- ✅ **Refund Support** — full create/verify/refund lifecycle for all gateways
+- ✅ **Refund APIs** — refund adapters are implemented across gateways; provider-side status and merchant entitlements determine runtime availability
 - ✅ **Sandbox / Production** — per-gateway environment toggle
 
 ---
@@ -425,6 +426,7 @@ Accepted `DatabaseProvider` values in `appsettings.json`:
 | `12` | OPay |
 | `13` | DPO Group |
 | `14` | PawaPay |
+| `15` | PeachPayments |
 
 ---
 
@@ -452,13 +454,13 @@ Accepted `DatabaseProvider` values in `appsettings.json`:
 
 ## Contributing
 
-Contributions are welcome! Please read our [Contributing Guide](https://github.com/teesofttech/PayBridge/blob/main/CONTRIBUTING.md) and open a Pull Request.
+Contributions are welcome! Please read our [Contributing Guide](https://github.com/teesofttech/PayBridge/blob/master/CONTRIBUTING.md) and open a Pull Request.
 
 ---
 
 ## License
 
-PayBridge.SDK is licensed under the [MIT License](https://github.com/teesofttech/PayBridge/blob/main/LICENSE).
+PayBridge.SDK is licensed under the [MIT License](https://github.com/teesofttech/PayBridge/blob/master/LICENSE).
 
 ---
 


### PR DESCRIPTION
## Summary
- fix default-branch links from main to master in repository and NuGet readmes
- remove stale Fincra mention from top-level README feature summary
- update NuGet README gateway count to 15 and add PeachPayments to supported table and enum map
- soften over-broad refund claim wording to match provider/runtime reality
- replace stale version-specific package description text in csproj metadata

## Validation
- grep checks for stale branch links and removed claims

## Notes
- This is a documentation and package-metadata alignment pass to reduce claim drift.
- Follow-up docs cleanup can still expand quick-start verification and link-check automation.

Addresses #84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated package and README descriptions to highlight secure webhook verification, deterministic routing, persistence support, and unified gateway integration.
  * Added PeachPayments to the documented gateway listings and payment gateway reference.
  * Clarified refund API availability and updated the supported gateway count.
  * Corrected repository links for badges, contributing guidance, and the MIT license.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->