### PR TITLE
Core: harden enabled gateway startup validation (#66)

### DIFF
--- a/PayBridge.SDK.Test/Unit/IServiceCollectionExtensionsTests.cs
+++ b/PayBridge.SDK.Test/Unit/IServiceCollectionExtensionsTests.cs
@@ -136,6 +136,57 @@ public class IServiceCollectionExtensionsTests
     }
 
     [Fact]
+    public void AddPayBridge_WhenEnabledGatewaysContainsDuplicateValues_Throws()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["PaymentGatewayConfig:EnabledGateways:0"] = "Paystack",
+            ["PaymentGatewayConfig:EnabledGateways:1"] = "Paystack",
+            ["PaymentGatewayConfig:Paystack:SecretKey"] = "sk_test_paystack"
+        });
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var action = () => services.AddPayBridge(configuration);
+
+        action.Should().Throw<Exception>()
+            .WithMessage("*appears more than once*");
+    }
+
+    [Fact]
+    public void AddPayBridge_WhenEnabledGatewayIsUndefinedEnumValue_Throws()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["PaymentGatewayConfig:EnabledGateways:0"] = "999"
+        });
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var action = () => services.AddPayBridge(configuration);
+
+        action.Should().Throw<Exception>()
+            .WithMessage("*not a defined PaymentGatewayType*");
+    }
+
+    [Fact]
+    public void AddPayBridge_WhenEnabledGatewayUsesPlaceholderCredential_Throws()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["PaymentGatewayConfig:EnabledGateways:0"] = "Paystack",
+            ["PaymentGatewayConfig:Paystack:SecretKey"] = "YOUR_PAYSTACK_SECRET_KEY"
+        });
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var action = () => services.AddPayBridge(configuration);
+
+        action.Should().Throw<Exception>()
+            .WithMessage("*Paystack*missing required configuration values*");
+    }
+
+    [Fact]
     public void AddPayBridge_WhenDefaultGatewayIsMissingRequiredConfig_Throws()
     {
         var configuration = BuildConfiguration(new Dictionary<string, string?>

--- a/PayBridge.SDK.Test/Unit/IServiceCollectionExtensionsTests.cs
+++ b/PayBridge.SDK.Test/Unit/IServiceCollectionExtensionsTests.cs
@@ -183,7 +183,7 @@ public class IServiceCollectionExtensionsTests
         var action = () => services.AddPayBridge(configuration);
 
         action.Should().Throw<Exception>()
-            .WithMessage("*Paystack*missing required configuration values*");
+            .WithMessage("*Paystack*missing required configuration values:*PaymentGatewayConfig:Paystack:SecretKey*");
     }
 
     [Fact]

--- a/PayBridge.SDK/Externsions/IServiceCollectionExtensions.cs
+++ b/PayBridge.SDK/Externsions/IServiceCollectionExtensions.cs
@@ -178,25 +178,58 @@ public static class IServiceCollectionExtensions
 
     private static void ValidateEnabledGatewayConfiguration(PaymentGatewayConfig config)
     {
+        var errors = new List<string>();
+        var seenGateways = new HashSet<PaymentGatewayType>();
+
         foreach (var gateway in config.EnabledGateways)
         {
+            if (!Enum.IsDefined(typeof(PaymentGatewayType), gateway))
+            {
+                errors.Add(
+                    $"Enabled gateway value '{(int)gateway}' is not a defined PaymentGatewayType.");
+                continue;
+            }
+
             if (gateway == PaymentGatewayType.Automatic)
             {
-                throw new PaymentConfigurationException(
+                errors.Add(
                     "PaymentGatewayConfig:EnabledGateways cannot include Automatic. " +
                     "Use concrete gateway types only.");
+                continue;
+            }
+
+            if (!seenGateways.Add(gateway))
+            {
+                errors.Add(
+                    $"Enabled gateway '{gateway}' appears more than once. " +
+                    "Remove duplicate entries.");
+                continue;
             }
 
             if (!IsGatewayConfigured(config, gateway))
             {
-                throw new PaymentConfigurationException(
+                errors.Add(
                     $"Enabled gateway '{gateway}' is missing required configuration values.");
             }
+        }
+
+        if (errors.Count > 0)
+        {
+            throw new PaymentConfigurationException(
+                "Invalid PaymentGatewayConfig:EnabledGateways configuration:" +
+                Environment.NewLine +
+                string.Join(Environment.NewLine, errors.Select(error => $" - {error}")));
         }
     }
 
     private static void ValidateDefaultGatewayConfiguration(PaymentGatewayConfig config)
     {
+        if (!Enum.IsDefined(typeof(PaymentGatewayType), config.DefaultGateway))
+        {
+            throw new PaymentConfigurationException(
+                $"Default gateway value '{(int)config.DefaultGateway}' is not a defined PaymentGatewayType.");
+        }
+
         if (config.DefaultGateway == PaymentGatewayType.Automatic)
         {
             return;

--- a/PayBridge.SDK/Externsions/IServiceCollectionExtensions.cs
+++ b/PayBridge.SDK/Externsions/IServiceCollectionExtensions.cs
@@ -208,8 +208,9 @@ public static class IServiceCollectionExtensions
 
             if (!IsGatewayConfigured(config, gateway))
             {
+                var missingSettings = GetMissingGatewayConfigurationKeys(config, gateway);
                 errors.Add(
-                    $"Enabled gateway '{gateway}' is missing required configuration values.");
+                    $"Enabled gateway '{gateway}' is missing required configuration values: {string.Join(", ", missingSettings)}.");
             }
         }
 
@@ -342,6 +343,80 @@ public static class IServiceCollectionExtensions
             PaymentGatewayType.PeachPayments => HasValue(config.PeachPayments.EntityId) && HasValue(config.PeachPayments.AccessToken),
             _ => false
         };
+    }
+
+    private static IReadOnlyList<string> GetMissingGatewayConfigurationKeys(PaymentGatewayConfig config, PaymentGatewayType gateway)
+    {
+        var missingSettings = new List<string>();
+
+        void AddIfMissing(string key, string value)
+        {
+            if (!HasValue(value))
+            {
+                missingSettings.Add(key);
+            }
+        }
+
+        switch (gateway)
+        {
+            case PaymentGatewayType.Paystack:
+                AddIfMissing("PaymentGatewayConfig:Paystack:SecretKey", config.Paystack.SecretKey);
+                break;
+            case PaymentGatewayType.Flutterwave:
+                AddIfMissing("PaymentGatewayConfig:FlutterwaveConfig:SecretKey", config.FlutterwaveConfig.SecretKey);
+                break;
+            case PaymentGatewayType.Stripe:
+                AddIfMissing("PaymentGatewayConfig:Stripe:SecretKey", config.Stripe.SecretKey);
+                break;
+            case PaymentGatewayType.Checkout:
+                AddIfMissing("PaymentGatewayConfig:Checkout:SecretKey", config.Checkout.SecretKey);
+                break;
+            case PaymentGatewayType.BenefitPay:
+                AddIfMissing("PaymentGatewayConfig:BenefitPay:MerchantId", config.BenefitPay.MerchantId);
+                AddIfMissing("PaymentGatewayConfig:BenefitPay:ApiKey", config.BenefitPay.ApiKey);
+                break;
+            case PaymentGatewayType.Knet:
+                AddIfMissing("PaymentGatewayConfig:Knet:TransportId", config.Knet.TransportId);
+                AddIfMissing("PaymentGatewayConfig:Knet:Password", config.Knet.Password);
+                break;
+            case PaymentGatewayType.Monnify:
+                AddIfMissing("PaymentGatewayConfig:Monnify:ApiKey", config.Monnify.ApiKey);
+                AddIfMissing("PaymentGatewayConfig:Monnify:SecretKey", config.Monnify.SecretKey);
+                AddIfMissing("PaymentGatewayConfig:Monnify:ContractCode", config.Monnify.ContractCode);
+                break;
+            case PaymentGatewayType.Squad:
+                AddIfMissing("PaymentGatewayConfig:Squad:SecretKey", config.Squad.SecretKey);
+                break;
+            case PaymentGatewayType.Korapay:
+                AddIfMissing("PaymentGatewayConfig:Korapay:SecretKey", config.Korapay.SecretKey);
+                break;
+            case PaymentGatewayType.Interswitch:
+                AddIfMissing("PaymentGatewayConfig:Interswitch:ClientId", config.Interswitch.ClientId);
+                AddIfMissing("PaymentGatewayConfig:Interswitch:ClientSecret", config.Interswitch.ClientSecret);
+                AddIfMissing("PaymentGatewayConfig:Interswitch:MerchantCode", config.Interswitch.MerchantCode);
+                break;
+            case PaymentGatewayType.Remita:
+                AddIfMissing("PaymentGatewayConfig:Remita:MerchantId", config.Remita.MerchantId);
+                AddIfMissing("PaymentGatewayConfig:Remita:ServiceTypeId", config.Remita.ServiceTypeId);
+                AddIfMissing("PaymentGatewayConfig:Remita:ApiKey", config.Remita.ApiKey);
+                break;
+            case PaymentGatewayType.Opay:
+                AddIfMissing("PaymentGatewayConfig:Opay:MerchantId", config.Opay.MerchantId);
+                AddIfMissing("PaymentGatewayConfig:Opay:SecretKey", config.Opay.SecretKey);
+                break;
+            case PaymentGatewayType.DpoGroup:
+                AddIfMissing("PaymentGatewayConfig:DpoGroup:CompanyToken", config.DpoGroup.CompanyToken);
+                break;
+            case PaymentGatewayType.PawaPay:
+                AddIfMissing("PaymentGatewayConfig:PawaPay:ApiToken", config.PawaPay.ApiToken);
+                break;
+            case PaymentGatewayType.PeachPayments:
+                AddIfMissing("PaymentGatewayConfig:PeachPayments:EntityId", config.PeachPayments.EntityId);
+                AddIfMissing("PaymentGatewayConfig:PeachPayments:AccessToken", config.PeachPayments.AccessToken);
+                break;
+        }
+
+        return missingSettings;
     }
 
     private static bool HasValue(string value)


### PR DESCRIPTION
## Summary
- validate `EnabledGateways` as a strict set: reject undefined enum values, reject `Automatic`, and reject duplicates
- keep placeholder credentials fail-fast behavior and ensure missing required fields are reported
- return a single aggregated startup configuration error containing all detected enabled-gateway issues
- validate undefined `DefaultGateway` values with a clear startup error
- add unit tests for duplicate, undefined, and placeholder-credential enabled-gateway cases

## Validation
- dotnet test PayBridge.SDK.Test/PayBridge.SDK.Test.csproj --filter "Category=Unit"
- result: 162 passed, 0 failed

Addresses #66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment gateway configuration validation.
  * Invalid, duplicate, or undefined enabled gateways are now reported clearly.
  * Missing gateway credentials are identified with their configuration paths.
  * Invalid default gateway values are rejected.
  * Multiple configuration issues are reported together in a single error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->