### PR TITLE
Implement refund idempotency and transactional reconciliation (#115 #116 #117)

### DIFF
--- a/PayBridge.SDK.Test/Unit/PaymentServiceRefundTests.cs
+++ b/PayBridge.SDK.Test/Unit/PaymentServiceRefundTests.cs
@@ -34,10 +34,8 @@ public class PaymentServiceRefundTests
         fixture.Refund.RefundReference.Should().Be("provider-refund");
         fixture.Refund.ProcessedAt.Should().Be(providerTimestamp);
         fixture.Refunds.Verify(repository =>
-            repository.UpdateAsync(fixture.Refund), Times.Once);
+            repository.FinalizeAsync(It.IsAny<RefundTransaction>(), It.IsAny<RefundResponse>()), Times.Once);
         fixture.Transaction.Status.Should().Be(PaymentStatus.Refunded);
-        fixture.Transactions.Verify(repository =>
-            repository.UpdateAsync(fixture.Transaction), Times.Once);
     }
 
     [Fact]
@@ -55,10 +53,8 @@ public class PaymentServiceRefundTests
 
         fixture.Refund.Status.Should().Be(PaymentStatus.Pending);
         fixture.Refunds.Verify(repository =>
-            repository.UpdateAsync(fixture.Refund), Times.Once);
+            repository.FinalizeAsync(It.IsAny<RefundTransaction>(), It.IsAny<RefundResponse>()), Times.Once);
         fixture.Transaction.Status.Should().Be(PaymentStatus.Successful);
-        fixture.Transactions.Verify(repository =>
-            repository.UpdateAsync(It.IsAny<PaymentTransaction>()), Times.Never);
     }
 
     [Fact]
@@ -78,7 +74,7 @@ public class PaymentServiceRefundTests
         fixture.Refund.ProcessedAt.Should().NotBeNull();
         fixture.Refund.GatewayResponse.Should().Contain("rejected");
         fixture.Refunds.Verify(repository =>
-            repository.UpdateAsync(fixture.Refund), Times.Once);
+            repository.FinalizeAsync(It.IsAny<RefundTransaction>(), It.IsAny<RefundResponse>()), Times.Once);
     }
 
     [Fact]
@@ -92,7 +88,7 @@ public class PaymentServiceRefundTests
         fixture.Refund.Status.Should().Be(PaymentStatus.Failed);
         fixture.Refund.ProcessedAt.Should().NotBeNull();
         fixture.Refunds.Verify(repository =>
-            repository.UpdateAsync(fixture.Refund), Times.Once);
+            repository.FinalizeAsync(It.IsAny<RefundTransaction>(), It.IsAny<RefundResponse>()), Times.Once);
     }
 
     [Fact]
@@ -109,6 +105,72 @@ public class PaymentServiceRefundTests
 
         await action.Should().ThrowAsync<Exception>()
             .WithMessage("*refundable balance*");
+        fixture.Gateway.Verify(gateway =>
+            gateway.RefundPaymentAsync(It.IsAny<RefundRequest>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RefundPaymentAsync_replays_stored_response_for_same_idempotency_request()
+    {
+        var fixture = CreateFixture(new RefundResponse { Success = true });
+        var stored = new RefundResponse
+        {
+            Success = true,
+            RefundReference = "stored-refund",
+            TransactionReference = "PAYMENT-1",
+            Message = "already processed",
+            Amount = 40m,
+            Status = PaymentStatus.Refunded,
+            RefundDate = DateTime.UtcNow.AddMinutes(-2)
+        };
+
+        fixture.Refunds
+            .Setup(repository => repository.GetByIdempotencyKeyAsync("refund-key-1"))
+            .ReturnsAsync(new RefundTransaction
+            {
+                Id = "refund-1",
+                IdempotencyKey = "refund-key-1",
+                PaymentTransactionReference = "PAYMENT-1",
+                Amount = 40m,
+                Currency = "NGN",
+                Status = PaymentStatus.Refunded,
+                RequestFingerprint = ComputeTestFingerprint(NewRequest(40m, "refund-key-1")),
+                GatewayResponse = System.Text.Json.JsonSerializer.Serialize(stored),
+                CreatedAt = DateTime.UtcNow.AddMinutes(-3),
+                ProcessedAt = stored.RefundDate
+            });
+
+        var response = await fixture.Service.RefundPaymentAsync(NewRequest(40m, "refund-key-1"));
+
+        response.RefundReference.Should().Be("stored-refund");
+        response.Status.Should().Be(PaymentStatus.Refunded);
+        fixture.Gateway.Verify(gateway =>
+            gateway.RefundPaymentAsync(It.IsAny<RefundRequest>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RefundPaymentAsync_rejects_reused_idempotency_key_with_different_payload()
+    {
+        var fixture = CreateFixture(new RefundResponse { Success = true });
+
+        fixture.Refunds
+            .Setup(repository => repository.GetByIdempotencyKeyAsync("refund-key-2"))
+            .ReturnsAsync(new RefundTransaction
+            {
+                Id = "refund-2",
+                IdempotencyKey = "refund-key-2",
+                PaymentTransactionReference = "PAYMENT-1",
+                Amount = 20m,
+                Currency = "NGN",
+                Status = PaymentStatus.Refunded,
+                RequestFingerprint = ComputeTestFingerprint(NewRequest(20m, "refund-key-2")),
+                CreatedAt = DateTime.UtcNow
+            });
+
+        var action = () => fixture.Service.RefundPaymentAsync(NewRequest(30m, "refund-key-2"));
+
+        await action.Should().ThrowAsync<Exception>()
+            .WithMessage("*different refund parameters*");
         fixture.Gateway.Verify(gateway =>
             gateway.RefundPaymentAsync(It.IsAny<RefundRequest>()), Times.Never);
     }
@@ -138,8 +200,29 @@ public class PaymentServiceRefundTests
                 transaction.Amount))
             .Callback<RefundTransaction, decimal>((refund, _) => capturedRefund = refund)
             .ReturnsAsync(true);
+        refunds.Setup(repository => repository.GetByIdempotencyKeyAsync(It.IsAny<string>()))
+            .ReturnsAsync((RefundTransaction?)null);
         refunds.Setup(repository => repository.UpdateAsync(It.IsAny<RefundTransaction>()))
             .ReturnsAsync((RefundTransaction refund) => refund);
+        refunds.Setup(repository => repository.FinalizeAsync(
+                It.IsAny<RefundTransaction>(),
+                It.IsAny<RefundResponse>()))
+            .ReturnsAsync((RefundTransaction refund, RefundResponse response) =>
+            {
+                refund.RefundReference = string.IsNullOrWhiteSpace(response.RefundReference)
+                    ? refund.Id
+                    : response.RefundReference;
+                refund.Status = response.Success ? response.Status : PaymentStatus.Failed;
+                refund.ProcessedAt = response.RefundDate == default ? DateTime.UtcNow : response.RefundDate;
+                refund.GatewayResponse = response.Message;
+
+                if (refund.Status == PaymentStatus.Refunded)
+                {
+                    transaction.Status = PaymentStatus.Refunded;
+                }
+
+                return refund;
+            });
         refunds.Setup(repository => repository.GetByPaymentReferenceAsync("PAYMENT-1"))
             .ReturnsAsync(() => capturedRefund is null
                 ? []
@@ -173,12 +256,25 @@ public class PaymentServiceRefundTests
             () => capturedRefund!);
     }
 
-    private static RefundRequest NewRequest(decimal amount) => new()
+    private static RefundRequest NewRequest(decimal amount, string? idempotencyKey = null) => new()
     {
         TransactionReference = "PAYMENT-1",
         Amount = amount,
-        Reason = "requested_by_customer"
+        Reason = "requested_by_customer",
+        IdempotencyKey = idempotencyKey
     };
+
+    private static string ComputeTestFingerprint(RefundRequest request)
+    {
+        var payload = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            request.TransactionReference,
+            request.Amount,
+            Reason = request.Reason ?? string.Empty
+        });
+        return Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(
+            System.Text.Encoding.UTF8.GetBytes(payload)));
+    }
 
     private sealed record Fixture(
         PaymentService Service,

--- a/PayBridge.SDK/Dtos/Request/RefundRequest.cs
+++ b/PayBridge.SDK/Dtos/Request/RefundRequest.cs
@@ -1,6 +1,7 @@
 ﻿namespace PayBridge.SDK.Application.Dtos.Request;
 public class RefundRequest
 {
+    public string? IdempotencyKey { get; set; }
     public string TransactionReference { get; set; } = string.Empty;
     public decimal Amount { get; set; }
     public string Reason { get; set; } = string.Empty;

--- a/PayBridge.SDK/Entities/RefundTransaction.cs
+++ b/PayBridge.SDK/Entities/RefundTransaction.cs
@@ -4,6 +4,11 @@ namespace PayBridge.SDK.Entities;
 public class RefundTransaction
 {
     /// <summary>
+    /// Optional application-level idempotency key for the refund attempt
+    /// </summary>
+    public string? IdempotencyKey { get; set; }
+
+    /// <summary>
     /// Unique identifier for the refund
     /// </summary>
     public string Id { get; set; } = string.Empty;
@@ -47,6 +52,11 @@ public class RefundTransaction
     /// Raw response from the payment gateway
     /// </summary>
     public string GatewayResponse { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Stable fingerprint of the refund request used to validate idempotent retries
+    /// </summary>
+    public string RequestFingerprint { get; set; } = string.Empty;
 
     /// <summary>
     /// When the refund was created

--- a/PayBridge.SDK/Interfaces/IRefundRepository.cs
+++ b/PayBridge.SDK/Interfaces/IRefundRepository.cs
@@ -1,4 +1,5 @@
 ﻿using PayBridge.SDK.Entities;
+using PayBridge.SDK.Dtos.Response;
 
 namespace PayBridge.SDK.Interfaces;
 
@@ -15,6 +16,11 @@ public interface IRefundRepository
     Task<bool> TryReserveAsync(RefundTransaction refund, decimal capturedAmount);
 
     /// <summary>
+    /// Gets a refund by its idempotency key.
+    /// </summary>
+    Task<RefundTransaction?> GetByIdempotencyKeyAsync(string idempotencyKey);
+
+    /// <summary>
     /// Gets a refund by its reference
     /// </summary>
     Task<RefundTransaction?> GetByReferenceAsync(string reference);
@@ -28,4 +34,9 @@ public interface IRefundRepository
     /// Updates an existing refund
     /// </summary>
     Task<RefundTransaction> UpdateAsync(RefundTransaction refund);
+
+    /// <summary>
+    /// Finalizes a refund and recalculates the parent payment status transactionally.
+    /// </summary>
+    Task<RefundTransaction> FinalizeAsync(RefundTransaction refund, RefundResponse response);
 }

--- a/PayBridge.SDK/Migrations/20260719140635_AddRefundIdempotency.Designer.cs
+++ b/PayBridge.SDK/Migrations/20260719140635_AddRefundIdempotency.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using PayBridge.SDK;
 
@@ -11,9 +12,11 @@ using PayBridge.SDK;
 namespace PayBridge.SDK.Migrations
 {
     [DbContext(typeof(PayBridgeDbContext))]
-    partial class PayBridgeDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260719140635_AddRefundIdempotency")]
+    partial class AddRefundIdempotency
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/PayBridge.SDK/Migrations/20260719140635_AddRefundIdempotency.cs
+++ b/PayBridge.SDK/Migrations/20260719140635_AddRefundIdempotency.cs
@@ -10,17 +10,18 @@ namespace PayBridge.SDK.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            var (keyType, fingerprintType) = GetProviderColumnTypes();
             migrationBuilder.AddColumn<string>(
                 name: "IdempotencyKey",
                 table: "Refunds",
-                type: "nvarchar(255)",
+                type: keyType,
                 maxLength: 255,
                 nullable: true);
 
             migrationBuilder.AddColumn<string>(
                 name: "RequestFingerprint",
                 table: "Refunds",
-                type: "nvarchar(64)",
+                type: fingerprintType,
                 maxLength: 64,
                 nullable: false,
                 defaultValue: "");
@@ -30,7 +31,29 @@ namespace PayBridge.SDK.Migrations
                 table: "Refunds",
                 column: "IdempotencyKey",
                 unique: true,
-                filter: "[IdempotencyKey] IS NOT NULL");
+                filter: ActiveProvider.Contains("SqlServer")
+                    ? "[IdempotencyKey] IS NOT NULL"
+                    : null);
+        }
+
+        private (string Key, string Fingerprint) GetProviderColumnTypes()
+        {
+            if (ActiveProvider.Contains("Npgsql"))
+            {
+                return ("character varying(255)", "character varying(64)");
+            }
+
+            if (ActiveProvider.Contains("MySql"))
+            {
+                return ("varchar(255)", "varchar(64)");
+            }
+
+            if (ActiveProvider.Contains("Sqlite"))
+            {
+                return ("TEXT", "TEXT");
+            }
+
+            return ("nvarchar(255)", "nvarchar(64)");
         }
 
         /// <inheritdoc />

--- a/PayBridge.SDK/Migrations/20260719140635_AddRefundIdempotency.cs
+++ b/PayBridge.SDK/Migrations/20260719140635_AddRefundIdempotency.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PayBridge.SDK.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRefundIdempotency : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "IdempotencyKey",
+                table: "Refunds",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "RequestFingerprint",
+                table: "Refunds",
+                type: "nvarchar(64)",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Refunds_IdempotencyKey",
+                table: "Refunds",
+                column: "IdempotencyKey",
+                unique: true,
+                filter: "[IdempotencyKey] IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Refunds_IdempotencyKey",
+                table: "Refunds");
+
+            migrationBuilder.DropColumn(
+                name: "IdempotencyKey",
+                table: "Refunds");
+
+            migrationBuilder.DropColumn(
+                name: "RequestFingerprint",
+                table: "Refunds");
+        }
+    }
+}

--- a/PayBridge.SDK/Persistence/PayBridgeDbContext.cs
+++ b/PayBridge.SDK/Persistence/PayBridgeDbContext.cs
@@ -25,5 +25,15 @@ public class PayBridgeDbContext : DbContext
 
         modelBuilder.Entity<RefundTransaction>()
             .HasIndex(refund => new { refund.PaymentTransactionReference, refund.Status });
+        modelBuilder.Entity<RefundTransaction>()
+            .HasIndex(refund => refund.IdempotencyKey)
+            .IsUnique()
+            .HasFilter("[IdempotencyKey] IS NOT NULL");
+        modelBuilder.Entity<RefundTransaction>()
+            .Property(refund => refund.IdempotencyKey)
+            .HasMaxLength(255);
+        modelBuilder.Entity<RefundTransaction>()
+            .Property(refund => refund.RequestFingerprint)
+            .HasMaxLength(64);
     }
 }

--- a/PayBridge.SDK/Repositories/RefundRepository.cs
+++ b/PayBridge.SDK/Repositories/RefundRepository.cs
@@ -1,8 +1,10 @@
 using System.Data;
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using PayBridge.SDK.Entities;
 using PayBridge.SDK.Enums;
+using PayBridge.SDK.Dtos.Response;
 using PayBridge.SDK.Interfaces;
 
 namespace PayBridge.SDK;
@@ -82,6 +84,13 @@ public sealed class RefundRepository(
         }
     }
 
+    public async Task<RefundTransaction?> GetByIdempotencyKeyAsync(string idempotencyKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(idempotencyKey);
+        return await _dbContext.Refunds
+            .FirstOrDefaultAsync(refund => refund.IdempotencyKey == idempotencyKey);
+    }
+
     public async Task<RefundTransaction?> GetByReferenceAsync(string reference)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(reference);
@@ -107,6 +116,64 @@ public sealed class RefundRepository(
         return refund;
     }
 
+    public async Task<RefundTransaction> FinalizeAsync(RefundTransaction refund, RefundResponse response)
+    {
+        ArgumentNullException.ThrowIfNull(refund);
+        ArgumentNullException.ThrowIfNull(response);
+
+        var strategy = _dbContext.Database.CreateExecutionStrategy();
+        return await strategy.ExecuteAsync(async () =>
+        {
+            await using var transaction = await _dbContext.Database.BeginTransactionAsync(
+                IsolationLevel.Serializable);
+
+            var trackedRefund = await _dbContext.Refunds
+                .FirstOrDefaultAsync(item => item.Id == refund.Id);
+            if (trackedRefund is null)
+            {
+                throw new InvalidOperationException($"Refund not found: {refund.Id}");
+            }
+
+            var payment = await _dbContext.Transactions
+                .FirstOrDefaultAsync(item => item.TransactionReference == trackedRefund.PaymentTransactionReference);
+            if (payment is null)
+            {
+                throw new InvalidOperationException(
+                    $"Payment transaction not found: {trackedRefund.PaymentTransactionReference}");
+            }
+
+            trackedRefund.RefundReference = string.IsNullOrWhiteSpace(response.RefundReference)
+                ? trackedRefund.Id
+                : response.RefundReference;
+            trackedRefund.Status = response.Success ? response.Status : PaymentStatus.Failed;
+            trackedRefund.ProcessedAt = trackedRefund.Status == PaymentStatus.Pending
+                ? null
+                : response.RefundDate == default ? DateTime.UtcNow : response.RefundDate;
+            trackedRefund.GatewayResponse = JsonSerializer.Serialize(response);
+
+            if (trackedRefund.Status == PaymentStatus.Refunded)
+            {
+                var confirmedAmount = await _dbContext.Refunds
+                    .Where(item =>
+                        item.PaymentTransactionReference == trackedRefund.PaymentTransactionReference &&
+                        item.Status == PaymentStatus.Refunded)
+                    .Select(item => item.Amount)
+                    .SumAsync();
+
+                if (confirmedAmount >= payment.Amount)
+                {
+                    payment.Status = PaymentStatus.Refunded;
+                    _dbContext.Transactions.Update(payment);
+                }
+            }
+
+            _dbContext.Refunds.Update(trackedRefund);
+            await _dbContext.SaveChangesAsync();
+            await transaction.CommitAsync();
+            return trackedRefund;
+        });
+    }
+
     private static void PrepareForInsert(RefundTransaction refund)
     {
         if (string.IsNullOrWhiteSpace(refund.Id))
@@ -117,6 +184,11 @@ public sealed class RefundRepository(
         if (string.IsNullOrWhiteSpace(refund.RefundReference))
         {
             refund.RefundReference = refund.Id;
+        }
+
+        if (string.IsNullOrWhiteSpace(refund.RequestFingerprint))
+        {
+            refund.RequestFingerprint = string.Empty;
         }
 
         if (refund.CreatedAt == default)

--- a/PayBridge.SDK/Repositories/RefundRepository.cs
+++ b/PayBridge.SDK/Repositories/RefundRepository.cs
@@ -145,6 +145,7 @@ public sealed class RefundRepository(
             trackedRefund.RefundReference = string.IsNullOrWhiteSpace(response.RefundReference)
                 ? trackedRefund.Id
                 : response.RefundReference;
+            var previousStatus = trackedRefund.Status;
             trackedRefund.Status = response.Success ? response.Status : PaymentStatus.Failed;
             trackedRefund.ProcessedAt = trackedRefund.Status == PaymentStatus.Pending
                 ? null
@@ -159,6 +160,11 @@ public sealed class RefundRepository(
                         item.Status == PaymentStatus.Refunded)
                     .Select(item => item.Amount)
                     .SumAsync();
+
+                if (previousStatus != PaymentStatus.Refunded)
+                {
+                    confirmedAmount += trackedRefund.Amount;
+                }
 
                 if (confirmedAmount >= payment.Amount)
                 {

--- a/PayBridge.SDK/Services/PaymentService.cs
+++ b/PayBridge.SDK/Services/PaymentService.cs
@@ -413,7 +413,7 @@ public class PaymentService : IPaymentService
         {
             Id = Guid.NewGuid().ToString("N"),
             PaymentTransactionReference = request.TransactionReference,
-            IdempotencyKey = request.IdempotencyKey ?? string.Empty,
+            IdempotencyKey = string.IsNullOrWhiteSpace(request.IdempotencyKey) ? null : request.IdempotencyKey,
             RequestFingerprint = fingerprint,
             Amount = request.Amount,
             Currency = transaction.Currency,

--- a/PayBridge.SDK/Services/PaymentService.cs
+++ b/PayBridge.SDK/Services/PaymentService.cs
@@ -371,10 +371,50 @@ public class PaymentService : IPaymentService
             throw new PaymentGatewayException($"Gateway {selectedGateway} is not configured");
         }
 
+        var fingerprint = ComputeRefundFingerprint(request);
+
+        if (!string.IsNullOrWhiteSpace(request.IdempotencyKey))
+        {
+            var existingRefund = await _refundRepository.GetByIdempotencyKeyAsync(request.IdempotencyKey);
+            if (existingRefund is not null)
+            {
+                if (!CryptographicOperations.FixedTimeEquals(
+                        Encoding.UTF8.GetBytes(existingRefund.RequestFingerprint),
+                        Encoding.UTF8.GetBytes(fingerprint)))
+                {
+                    throw new PaymentGatewayException(
+                        "The idempotency key was already used with different refund parameters.");
+                }
+
+                if (!string.IsNullOrWhiteSpace(existingRefund.GatewayResponse))
+                {
+                    var storedResponse = JsonSerializer.Deserialize<RefundResponse>(existingRefund.GatewayResponse)
+                        ?? throw new PaymentGatewayException("The stored refund response is invalid.");
+
+                    return storedResponse;
+                }
+
+                return new RefundResponse
+                {
+                    Success = existingRefund.Status == PaymentStatus.Refunded,
+                    TransactionReference = existingRefund.PaymentTransactionReference,
+                    RefundReference = existingRefund.RefundReference,
+                    Amount = existingRefund.Amount,
+                    Status = existingRefund.Status,
+                    Message = existingRefund.Status == PaymentStatus.Pending
+                        ? "Refund is still processing"
+                        : "Refund already recorded",
+                    RefundDate = existingRefund.ProcessedAt ?? existingRefund.CreatedAt
+                };
+            }
+        }
+
         var refund = new RefundTransaction
         {
             Id = Guid.NewGuid().ToString("N"),
             PaymentTransactionReference = request.TransactionReference,
+            IdempotencyKey = request.IdempotencyKey ?? string.Empty,
+            RequestFingerprint = fingerprint,
             Amount = request.Amount,
             Currency = transaction.Currency,
             Reason = request.Reason,
@@ -399,13 +439,16 @@ public class PaymentService : IPaymentService
         }
         catch (Exception ex)
         {
-            refund.Status = PaymentStatus.Failed;
-            refund.ProcessedAt = DateTime.UtcNow;
-            refund.GatewayResponse = JsonSerializer.Serialize(new
+            await _refundRepository.FinalizeAsync(refund, new RefundResponse
             {
-                ErrorType = ex.GetType().Name
+                Success = false,
+                TransactionReference = request.TransactionReference,
+                RefundReference = refund.RefundReference,
+                Amount = request.Amount,
+                Status = PaymentStatus.Failed,
+                Message = ex.Message,
+                RefundDate = DateTime.UtcNow
             });
-            await _refundRepository.UpdateAsync(refund);
             _logger.LogError(ex, "Refund processing failed with {Gateway}", selectedGateway);
             throw new PaymentGatewayException($"Refund processing failed with {selectedGateway}", ex);
         }
@@ -413,31 +456,29 @@ public class PaymentService : IPaymentService
         _logger.LogInformation("Refund processing {Status}: {Reference}, Refund Reference: {RefundReference}",
             response.Success ? "successful" : "failed", request.TransactionReference, response.RefundReference);
 
-        refund.RefundReference = string.IsNullOrWhiteSpace(response.RefundReference)
-            ? refund.Id
-            : response.RefundReference;
-        refund.Status = response.Success ? response.Status : PaymentStatus.Failed;
-        refund.ProcessedAt = refund.Status == PaymentStatus.Pending
-            ? null
-            : response.RefundDate == default ? DateTime.UtcNow : response.RefundDate;
-        refund.GatewayResponse = JsonSerializer.Serialize(response);
-        await _refundRepository.UpdateAsync(refund);
+        var finalizedRefund = await _refundRepository.FinalizeAsync(refund, response);
 
-        if (refund.Status == PaymentStatus.Refunded)
+        return new RefundResponse
         {
-            var refunds = await _refundRepository.GetByPaymentReferenceAsync(
-                request.TransactionReference);
-            var confirmedAmount = refunds
-                .Where(item => item.Status == PaymentStatus.Refunded)
-                .Sum(item => item.Amount);
-            if (confirmedAmount >= transaction.Amount)
-            {
-                transaction.Status = PaymentStatus.Refunded;
-                await _transactionRepository.UpdateAsync(transaction);
-            }
-        }
+            Success = finalizedRefund.Status == PaymentStatus.Refunded,
+            RefundReference = finalizedRefund.RefundReference,
+            TransactionReference = finalizedRefund.PaymentTransactionReference,
+            Message = response.Message,
+            Amount = finalizedRefund.Amount,
+            Status = finalizedRefund.Status,
+            RefundDate = finalizedRefund.ProcessedAt ?? finalizedRefund.CreatedAt
+        };
+    }
 
-        return response;
+    private static string ComputeRefundFingerprint(RefundRequest request)
+    {
+        var payload = JsonSerializer.Serialize(new
+        {
+            request.TransactionReference,
+            request.Amount,
+            Reason = request.Reason ?? string.Empty
+        });
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(payload)));
     }
 
     private PaymentGatewayType SelectBestGateway(PaymentRequest request)


### PR DESCRIPTION
## Summary
- add refund idempotency support via request and persistence contracts
- add transactional refund finalization in repository to reconcile refund + payment state atomically
- refactor refund flow in payment service to replay idempotent retries and reject mismatched payload reuse
- add EF Core migration for refund idempotency key and request fingerprint
- expand refund unit tests for idempotent replay and mismatched-key rejection

## Validation
- dotnet test PayBridge.SDK.Test/PayBridge.SDK.Test.csproj --filter "FullyQualifiedName~PaymentServiceRefundTests|FullyQualifiedName~RefundRepositoryTests"
- dotnet test PayBridge.SDK.Test/PayBridge.SDK.Test.csproj --filter "FullyQualifiedName~Refund"
- dotnet build PayBridge.SDK.sln -c Release

Closes #115
Closes #116
Closes #117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added refund idempotency support via an optional idempotency key to prevent duplicate refund attempts on retries.
  * Identical retry requests now replay the previously stored refund result.
  * Reusing a key with different refund details is rejected.
  * Refund outcomes are now finalized consistently and the related payment is updated when the refund is confirmed.
* **Database**
  * Updated the schema to store refund idempotency keys and request fingerprints with uniqueness enforcement.
* **Tests**
  * Added unit tests covering idempotent replay, conflicting-request rejection, and the refund finalization flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->